### PR TITLE
Added option to build local RPM package for Fedora

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,3 +63,8 @@ fuse3 = { version = "0.7.1", features = ["tokio-runtime", "unprivileged"] }
 
 [package.metadata.aur]
 depends = ["fuse3"]
+
+[package.metadata.generate-rpm]
+assets = [
+    { source = "target/release/rencfs", dest = "/usr/bin/rencfs", mode = "755" }
+]

--- a/README.md
+++ b/README.md
@@ -264,6 +264,12 @@ Ubuntu
 sudo apt-get update && sudo apt-get install fuse3 build-essential
 ```
 
+Fedora
+
+```bash
+sudo dnf update && sudo dnf install fuse3
+```
+
 ### Build for debug
 
 ```bash
@@ -280,6 +286,25 @@ cargo build --release
 
 ```bash
 cargo run -- --mount-point MOUNT_POINT --data-dir DATA_DIR
+```
+
+### Build local RPM for Fedora
+
+This is using [cargo-generate-rpm](https://crates.io/crates/cargo-generate-rpm)
+
+```bash
+cargo install cargo-generate-rpm
+cargo build --release
+cargo generate-rpm
+```
+
+The generated RPM will be located here: `target/generate-rpm`.
+
+#### Install and run local RPM
+
+```bash
+cd target/generate-rpm/
+sudo dnf localinstall rencfs-xxx.x86_64.rpm
 ```
 
 ## Developing inside a Container


### PR DESCRIPTION
> [!NOTE]
> Added the ability to build local RPM for installation on RPM based distributions.

### Build local RPM for Fedora

This is using [cargo-generate-rpm](https://crates.io/crates/cargo-generate-rpm)

```bash
cargo install cargo-generate-rpm
cargo build --release
cargo generate-rpm
```

The generated RPM will be located here: `target/generate-rpm`.

#### Install and run local RPM

```bash
cd target/generate-rpm/
sudo dnf localinstall rencfs-xxx.x86_64.rpm
```


> [!TIP]
> The destination of the binary is set in the `[package.metadata.generate-rpm]` options inside the `Cargo.toml` file.
> By default, the installation location is set to `/usr/bin/rencfs`.
> DNF will know where the binary is installed and it will remove it upon unistallation:
> `sudo dnf remove rencfs`