### PR TITLE
Remove dsa keytype

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,7 +72,7 @@ jobs:
           commit_email: ${{ secrets.AUR_EMAIL }}
           ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
           commit_message: Update AUR package
-          ssh_keyscan_types: rsa,dsa,ecdsa,ed25519
+          ssh_keyscan_types: rsa,ecdsa,ed25519
 
   cargo_publish:
     name: publish to crates.io


### PR DESCRIPTION
The DSA keytype is disabled by default in openSSH starting from 7.0 onwards;
See this : https://lwn.net/Articles/958048/ 
Our build machine based on Ubuntu probably has openssh by default and that's why the key add in the action fails for this type.  