### PR TITLE
Hide folder structure #208

### DIFF
--- a/src/encryptedfs.rs
+++ b/src/encryptedfs.rs
@@ -674,7 +674,7 @@ impl EncryptedFs {
             return Ok(true);
         }
         let file = async_util::call_async(async {
-            crypto::decrypt_file_name(filename, self.cipher, &*self.key.get().await.unwrap())
+            crypto::decrypt_file_name(filename, self.cipher, &self.key.get().await.unwrap())
         });
         Ok(!file?.expose_secret().starts_with("0"))
     }
@@ -795,7 +795,7 @@ impl EncryptedFs {
                                 for _ in 1..num_files {
                                     let fake_file_name =
                                         get_random_secret_filename(&self_clone).await?;
-                                    File::create(&fake_dir_path.join(fake_file_name))?;
+                                    File::create(fake_dir_path.join(fake_file_name))?;
                                 }
                             }
 

--- a/src/encryptedfs.rs
+++ b/src/encryptedfs.rs
@@ -670,6 +670,9 @@ impl EncryptedFs {
     }
 
     fn is_real_file_name(&self, filename: &str) -> FsResult<bool> {
+        if filename == "$." || filename == "$.." {
+            return Ok(true);
+        }
         let file = async_util::call_async(async {
             crypto::decrypt_file_name(filename, self.cipher, &*self.key.get().await.unwrap())
         });
@@ -1150,14 +1153,18 @@ impl EncryptedFs {
         let futures: Vec<_> = read_dir
             .into_iter()
             .filter_map(|entry| {
-                let real_file = self.is_real_file_name(
-                    &entry
+                let filename = entry
                         .as_ref()
                         .unwrap()
                         .file_name()
                         .into_string()
-                        .unwrap()
-                ).unwrap();
+                        .unwrap();
+
+                let real_file = match self.is_real_file_name(&filename) {
+                    Ok(file) => file,
+                    Err(e) => panic!("{filename} - {e}"),
+                };
+
                 if !real_file { return None; };
                 let fs = {
                     self.self_weak
@@ -1273,14 +1280,18 @@ impl EncryptedFs {
         let futures: Vec<_> = read_dir
             .into_iter()
             .filter_map(|entry| {
-                let real_file = self.is_real_file_name(
-                    &entry
+                let filename = entry
                         .as_ref()
                         .unwrap()
                         .file_name()
                         .into_string()
-                        .unwrap()
-                ).unwrap();
+                        .unwrap();
+
+                let real_file = match self.is_real_file_name(&filename) {
+                    Ok(file) => file,
+                    Err(e) => panic!("{filename} - {e}"),
+                };
+
                 if !real_file { return None; };
                 let fs = {
                     self.self_weak

--- a/src/encryptedfs.rs
+++ b/src/encryptedfs.rs
@@ -3,6 +3,7 @@ use async_trait::async_trait;
 use futures_util::TryStreamExt;
 use lru::LruCache;
 use num_format::{Locale, ToFormattedString};
+use rand::Rng;
 use serde::{Deserialize, Serialize};
 use shush_rs::{ExposeSecret, SecretBox, SecretString, SecretVec};
 use std::backtrace::Backtrace;
@@ -668,6 +669,11 @@ impl EncryptedFs {
         }
     }
 
+    async fn is_real_file_name(&self, filename: &str) -> FsResult<bool> {
+        let file = crypto::decrypt_file_name(filename, self.cipher, &*self.key.get().await?).unwrap();
+        Ok(!file.expose_secret().starts_with("0"))
+    }
+
     /// Create a new node in the filesystem
     #[allow(clippy::missing_panics_doc)]
     #[allow(clippy::missing_errors_doc)]
@@ -748,6 +754,47 @@ impl EncryptedFs {
                             // used to keep hashes of encrypted file names used by [`exists_by_name`] and [`find_by_name`]
                             // this optimizes the search process as we don't need to decrypt all file names and search
                             fs::create_dir(contents_dir.join(HASH_DIR))?;
+
+                            fn get_random_number(from: u8, to: u8) -> u8 {
+                                rand::thread_rng().gen_range(from..to)
+                            }
+
+                            async fn get_random_secret_filename(encryptedfs: &EncryptedFs) -> FsResult<String> {
+                                let length = rand::thread_rng().gen_range(5..20);
+                                let rng = rand::thread_rng();
+                                let random_name: String = rng.sample_iter(rand::distributions::Alphanumeric)
+                                    .take(length)
+                                    .map(char::from)
+                                    .collect();
+                                let secret_name = SecretString::from_str(&format!("0{random_name}")).unwrap();
+                                crypto::encrypt_file_name(
+                                    &secret_name, 
+                                    encryptedfs.cipher,
+                                    &*encryptedfs.key.get().await?
+                                )
+                            }
+
+                            // create extra folders
+                            let num_folders = get_random_number(10, 100);
+                            for _ in 1..num_folders {
+                                let fake_dir_name = get_random_secret_filename(&self).await?;
+                                let fake_dir_path = contents_dir.join(fake_dir_name);
+                                fs::create_dir(&fake_dir_path)?;
+
+                                // create extra files inside the folders
+                                let num_files = get_random_number(10, 100);
+                                for _ in 1..num_files {
+                                    let fake_file_name = get_random_secret_filename(&self).await?;
+                                    File::create(&fake_dir_path.join(fake_file_name));
+                                }
+                            }
+
+                            // create extra files
+                            let num_files = get_random_number(10, 100);
+                            for _ in 1..num_files {
+                                let fake_file_name = get_random_secret_filename(&self).await?;
+                                File::create(contents_dir.join(fake_file_name.into()));
+                            }
 
                             // add "." and ".." entries
                             self_clone
@@ -1055,6 +1102,10 @@ impl EncryptedFs {
         }
 
         let iter = fs::read_dir(ls_dir)?;
+        let iter = fs::read_dir(ls_dir)?;
+        let iter = iter.filter(|&entry|
+            self.is_real_file_name(&entry.unwrap().file_name().into_string()).await
+        ).collect();
         let set_attr = SetFileAttr::default().with_atime(SystemTime::now());
         self.set_attr(ino, set_attr).await?;
         Ok(self.create_directory_entry_iterator(iter).await)
@@ -1071,6 +1122,9 @@ impl EncryptedFs {
         }
 
         let iter = fs::read_dir(ls_dir)?;
+        let iter = iter.filter(|&entry|
+            self.is_real_file_name(&entry.unwrap().file_name().into_string()).await
+        ).collect();
         let set_attr = SetFileAttr::default().with_atime(SystemTime::now());
         self.set_attr(ino, set_attr).await?;
         Ok(self.create_directory_entry_plus_iterator(iter).await)

--- a/src/encryptedfs.rs
+++ b/src/encryptedfs.rs
@@ -777,14 +777,14 @@ impl EncryptedFs {
                             // create extra folders
                             let num_folders = get_random_number(10, 100);
                             for _ in 1..num_folders {
-                                let fake_dir_name = get_random_secret_filename(&self).await?;
+                                let fake_dir_name = get_random_secret_filename(&self_clone).await?;
                                 let fake_dir_path = contents_dir.join(fake_dir_name);
                                 fs::create_dir(&fake_dir_path)?;
 
                                 // create extra files inside the folders
                                 let num_files = get_random_number(10, 100);
                                 for _ in 1..num_files {
-                                    let fake_file_name = get_random_secret_filename(&self).await?;
+                                    let fake_file_name = get_random_secret_filename(&self_clone).await?;
                                     File::create(&fake_dir_path.join(fake_file_name));
                                 }
                             }
@@ -792,8 +792,8 @@ impl EncryptedFs {
                             // create extra files
                             let num_files = get_random_number(10, 100);
                             for _ in 1..num_files {
-                                let fake_file_name = get_random_secret_filename(&self).await?;
-                                File::create(contents_dir.join(fake_file_name.into()));
+                                let fake_file_name = get_random_secret_filename(&self_clone).await?;
+                                File::create(contents_dir.join(fake_file_name));
                             }
 
                             // add "." and ".." entries

--- a/src/encryptedfs.rs
+++ b/src/encryptedfs.rs
@@ -1149,7 +1149,16 @@ impl EncryptedFs {
         #[allow(clippy::cast_possible_truncation)]
         let futures: Vec<_> = read_dir
             .into_iter()
-            .map(|entry| {
+            .filter_map(|entry| {
+                let real_file = self.is_real_file_name(
+                    &entry
+                        .as_ref()
+                        .unwrap()
+                        .file_name()
+                        .into_string()
+                        .unwrap()
+                ).unwrap();
+                if !real_file { return None; };
                 let fs = {
                     self.self_weak
                         .lock()
@@ -1159,7 +1168,7 @@ impl EncryptedFs {
                         .upgrade()
                         .unwrap()
                 };
-                DIR_ENTRIES_RT.spawn(async move { fs.create_directory_entry_plus(entry).await })
+                Some(DIR_ENTRIES_RT.spawn(async move { fs.create_directory_entry(entry).await }))
             })
             .collect();
 
@@ -1263,7 +1272,16 @@ impl EncryptedFs {
         #[allow(clippy::cast_possible_truncation)]
         let futures: Vec<_> = read_dir
             .into_iter()
-            .map(|entry| {
+            .filter_map(|entry| {
+                let real_file = self.is_real_file_name(
+                    &entry
+                        .as_ref()
+                        .unwrap()
+                        .file_name()
+                        .into_string()
+                        .unwrap()
+                ).unwrap();
+                if !real_file { return None; };
                 let fs = {
                     self.self_weak
                         .lock()
@@ -1273,7 +1291,7 @@ impl EncryptedFs {
                         .upgrade()
                         .unwrap()
                 };
-                DIR_ENTRIES_RT.spawn(async move { fs.create_directory_entry(entry).await })
+                Some(DIR_ENTRIES_RT.spawn(async move { fs.create_directory_entry(entry).await }))
             })
             .collect();
 

--- a/src/encryptedfs.rs
+++ b/src/encryptedfs.rs
@@ -1102,9 +1102,6 @@ impl EncryptedFs {
         }
 
         let iter = fs::read_dir(ls_dir)?;
-        let iter = iter.filter(|&entry|
-            self.is_real_file_name(&entry.unwrap().file_name().into_string()).await
-        ).collect();
         let set_attr = SetFileAttr::default().with_atime(SystemTime::now());
         self.set_attr(ino, set_attr).await?;
         Ok(self.create_directory_entry_iterator(iter).await)
@@ -1121,9 +1118,6 @@ impl EncryptedFs {
         }
 
         let iter = fs::read_dir(ls_dir)?;
-        let iter = iter.filter(|&entry|
-            self.is_real_file_name(&entry.unwrap().file_name().into_string()).await
-        ).collect();
         let set_attr = SetFileAttr::default().with_atime(SystemTime::now());
         self.set_attr(ino, set_attr).await?;
         Ok(self.create_directory_entry_plus_iterator(iter).await)

--- a/src/encryptedfs.rs
+++ b/src/encryptedfs.rs
@@ -1102,7 +1102,6 @@ impl EncryptedFs {
         }
 
         let iter = fs::read_dir(ls_dir)?;
-        let iter = fs::read_dir(ls_dir)?;
         let iter = iter.filter(|&entry|
             self.is_real_file_name(&entry.unwrap().file_name().into_string()).await
         ).collect();

--- a/src/encryptedfs.rs
+++ b/src/encryptedfs.rs
@@ -1168,7 +1168,7 @@ impl EncryptedFs {
                         .upgrade()
                         .unwrap()
                 };
-                Some(DIR_ENTRIES_RT.spawn(async move { fs.create_directory_entry(entry).await }))
+                Some(DIR_ENTRIES_RT.spawn(async move { fs.create_directory_entry_plus(entry).await }))
             })
             .collect();
 

--- a/src/encryptedfs.rs
+++ b/src/encryptedfs.rs
@@ -787,7 +787,7 @@ impl EncryptedFs {
                                 let num_files = get_random_number(10, 100);
                                 for _ in 1..num_files {
                                     let fake_file_name = get_random_secret_filename(&self_clone).await?;
-                                    File::create(&fake_dir_path.join(fake_file_name));
+                                    File::create(&fake_dir_path.join(fake_file_name))?;
                                 }
                             }
 
@@ -795,7 +795,7 @@ impl EncryptedFs {
                             let num_files = get_random_number(10, 100);
                             for _ in 1..num_files {
                                 let fake_file_name = get_random_secret_filename(&self_clone).await?;
-                                File::create(contents_dir.join(fake_file_name));
+                                File::create(contents_dir.join(fake_file_name))?;
                             }
 
                             // add "." and ".." entries

--- a/src/encryptedfs/test.rs
+++ b/src/encryptedfs/test.rs
@@ -23,7 +23,7 @@ use crate::{crypto, test_common};
 
 static ROOT_INODE_STR: &str = "1";
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[traced_test]
 #[allow(clippy::too_many_lines)]
 async fn test_write() {
@@ -530,7 +530,7 @@ async fn test_copy_file_range() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[traced_test]
 #[allow(clippy::too_many_lines)]
 async fn test_read_dir() {
@@ -726,7 +726,7 @@ async fn test_read_dir() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[traced_test]
 #[allow(clippy::too_many_lines)]
 async fn test_read_dir_plus() {
@@ -1188,7 +1188,7 @@ async fn test_create_structure_and_root() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[traced_test]
 #[allow(clippy::too_many_lines)]
 async fn test_create() {
@@ -1379,7 +1379,7 @@ async fn test_create() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[traced_test]
 #[allow(clippy::too_many_lines)]
 async fn test_rename() {


### PR DESCRIPTION
## Description

Fixes #208

* added 2 functions inside `EncryptedFs::create`:
  * `get_random_number` - generates a random number between `from` and `to`
  * `get_random_secret_filename` - generates a random-length random encrypted file name asynchronously
* created fake folders (with fake files inside of them) and fake files, using the 2 functions mentioned above, in `EncryptedFs::create`
* added `EncryptedFs::is_real_file_name` method which returns `true` if an encrypted file is real, `false` otherwise
  * works by decrypting the filename and checking if the first character is `0`  
* ~~filtered the `iter` object using the aforementioned function in `EncryptedFs::read_dir` and `EncryptedFs::read_dir_plus`~~
* filter and map entries in `EncryptedFs::create_directory_entry_plus_iterator` and `EncryptedFs::create_directory_entry_iterator`, depending if they are real files or not
* add `flavor = "multi_thread"` to `tokio::test` 

---

## Problems
* ~~errors `E0728`, `E0308` and `E0277` inside `iter.filter` (in both `read_dir` functions)~~
  * ~~I cannot seem to call the `async` `is_real_file_name` function~~
  * ~~I also cannot get the right type for the argument~~
* ~~on the line with the last `File::create` inside `EncryptedFs::create` I get a `type unknown`/`type annotation needed` error when calling it as `File::create(contents_dir.join(fake_file_name.into()));`. If I remove `.into()`, I get an error `E0521` on the entire `EncryptedFs::create` function call. I do not know how to fix either of them~~

---

## Todo:

- [x] Fix the above errors (assistance needed)
- [x] Remove accidental duplication of the line `let iter = fs::read_dir(ls_dir)?;` in `EncryptedFs::read_dir`