### PR TITLE
[#192] See what can be used instead of [!WARNING] in readme file to be rendered on crates.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <a href="https://join.slack.com/t/rencfs/shared_invite/zt-2w9cpnql2-o0qtN_rXFNjHvp92qFhXCg"><img src="website/resources/slack.png" style = "width: 20px; height: 20px;"/></a>
 [![Open Source Helpers](https://www.codetriage.com/xoriors/rencfs/badges/users.svg?count=20)](https://www.codetriage.com/xoriors/rencfs)
 
-> [!WARNING]  
+> ⚠️ **Warning** 
 > **This crate hasn't been audited; it's using `ring` crate, which is a well-known audited library, so in principle, at
 least the primitives should offer a similar level of security.  
 > This is still under development. Please do not use it with sensitive data for now; please wait for a


### PR DESCRIPTION
Updated the warning section in the README file to ensure it renders correctly on crates.io. Replaced the [!WARNING] directive with alternative formatting that is supported by crates.io markdown.

This change ensures a clearer warning for users of the crate about the ongoing development status.

## Title

[#192] See what can be used instead of [!WARNING] in readme file to be rendered on crates.io

## Description

Updated the warning section in the README file to ensure it renders correctly on crates.io.
Replaced the [!WARNING] directive with alternative formatting that crates.io supports.

Implementation for #192

Fixes # (issue)

Fixes #192

## Type of change

Please delete options that are not relevant.

- [x] Documentation update

---

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have added necessary documentation (if appropriate)

---

## Screenshots (if applicable)

Add screenshots to illustrate changes if necessary.

---

## Additional Context

Add any additional context or information here.
