### PR TITLE
[#217] Add 3rd-party crate license validation and documentation generation

### DIFF
--- a/.github/workflows/build_and_tests_reusable.yaml
+++ b/.github/workflows/build_and_tests_reusable.yaml
@@ -39,17 +39,6 @@ jobs:
           cargo install cargo-aur
           cargo install cargo-generate-rpm          
 
-      - name: setup licence tools
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y jq
-          cargo install cargo-license
-
-      - name: licence check
-        if: matrix.os == 'ubuntu-latest'
-        run: bash scripts/check-licenses.sh
-
       - name: build
         run: |
           cargo build --all-targets --all-features

--- a/.github/workflows/build_and_tests_reusable.yaml
+++ b/.github/workflows/build_and_tests_reusable.yaml
@@ -39,6 +39,17 @@ jobs:
           cargo install cargo-aur
           cargo install cargo-generate-rpm          
 
+      - name: setup licence tools
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq
+          cargo install cargo-license
+
+      - name: licence check
+        if: matrix.os == 'ubuntu-latest'
+        run: bash scripts/check-licenses.sh
+
       - name: build
         run: |
           cargo build --all-targets --all-features

--- a/.github/workflows/package_reusable.yaml
+++ b/.github/workflows/package_reusable.yaml
@@ -30,6 +30,15 @@ jobs:
           cargo install cargo-aur
           cargo install cargo-generate-rpm          
 
+      - name: setup licence tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq
+          cargo install cargo-license
+
+      - name: licence check
+        run: bash scripts/check-licenses.sh
+
       - name: run cargo aur and generate-rpm
         run: |
           cargo aur

--- a/scripts/check-licenses.sh
+++ b/scripts/check-licenses.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -eo pipefail
+
+# install dependencies (useful for local checking)
+command -v jq >/dev/null || sudo apt-get install -y jq
+command -v cargo-license >/dev/null || cargo install cargo-license
+
+echo "Validating licenses..."
+
+# names of packages to exclude from check
+WHITELIST=("ring")
+
+ALLOWED_LICENSES="MIT|Apache-2.0|BSD-3-Clause|Unlicense"
+
+# find packages with disallowed licenses
+DISALLOWED=$(cargo license --all-features --direct-deps-only --json |
+  jq -r '.[] | "\(.name)\t\(.license // "NULL")"' |
+  while IFS=$'\t' read -r name license; do
+    if [[ " ${WHITELIST[*]} " =~ " $name " ]]; then
+      continue
+    fi
+    
+    if [[ "$license" == "NULL" || ! "$license" =~ $ALLOWED_LICENSES ]]; then
+      echo "$name ($license)"
+    fi
+  done
+)
+
+if [ -n "$DISALLOWED" ]; then
+  echo "Disallowed licenses found:"
+  echo "$DISALLOWED"
+  exit 1
+fi
+
+# generate THIRD-PARTY-LICENSES.md
+echo -e "# THIRD PARTY LICENSES:\n" > docs/THIRD-PARTY-LICENSES.md
+cargo license --all-features --direct-deps-only --json |
+  jq -r '
+    .[] | 
+    "## \(.name)\n" +
+    "- Version: \(.version)\n" +
+    "- License: \(.license // "UNKNOWN")\n" +
+    "- Repository: \(.repository // "")\n"
+  ' >> docs/THIRD-PARTY-LICENSES.md
+
+# copy license specific files
+mkdir -p docs/third-party-licenses
+cargo vendor --versioned-dirs vendor >/dev/null 2>&1
+find vendor -type f \
+    \( -iname 'LICENSE*' -o -iname 'NOTICE*' -o -iname 'COPYING*' \) \
+    -exec cp --parents {} docs/third-party-licenses/ \;
+
+# cleanup
+rm -rf vendor
+
+echo "License check passed"


### PR DESCRIPTION
## Title

Add 3rd-party license check and documentation generation

## Description

Adds a script that validates crate licenses and generates documentation:

- Checks all direct dependency licenses with `cargo-license`.
- Fails if any non-whitelisted crate with a disallowed license is found.
- If validation passes, it generates:
  - `/THIRD-PARTY-LICENSES.md`: A summary containing each crate's name, version, license type, repository URL, and paths to the generated license files.
  - `/licenses/`: A directory containing license-specific files (`LICENSE`, `NOTICE`, `COPYING`), using `cargo vendor`.

The check is added as a step in the package_reusable.yaml workflow.

The generated files are not automatically added to version control.

Fixes #217

---

## Type of change

- [x] New feature (non-breaking change which adds functionality)

---

## Checklist

- [x] I have performed a self-review of my code  
- [ ] I have tested my code on different platforms (if applicable)  
- [x] I have commented my code, particularly in hard-to-understand areas  
- [ ] I have added necessary documentation (if appropriate)  
- [x] My changes generate no new warnings  
- [ ] I have added tests that prove my fix is effective or that my feature works  
- [x] New and existing unit tests pass locally with my changes
