### PR TITLE
[#112] Use walkdir for read_dir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1887,6 +1887,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "tracing-test",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ subtle = "2.6.1"
 bon = "3.3.0"
 shush-rs = "0.1.10"
 criterion = { version = "0.5.1", features = ["html_reports"] }
+walkdir = "2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 fuse3 = { version = "0.8.1", features = ["tokio-runtime", "unprivileged"] }

--- a/java-bridge/Cargo.lock
+++ b/java-bridge/Cargo.lock
@@ -1965,6 +1965,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "tracing-test",
+ "walkdir",
 ]
 
 [[package]]

--- a/src/encryptedfs.rs
+++ b/src/encryptedfs.rs
@@ -1059,7 +1059,7 @@ impl EncryptedFs {
         Ok(self.create_directory_entry_iterator(ls_dir).await)
     }
 
-    // Like [`EncryptedFs::read_dir`] but with [`FileAttr`] so we don't need to query again for those.
+    /// Like [`EncryptedFs::read_dir`] but with [`FileAttr`] so we don't need to query again for those.
     pub async fn read_dir_plus(&self, ino: u64) -> FsResult<DirectoryEntryPlusIterator> {
         if !self.is_dir(ino) {
             return Err(FsError::InvalidInodeType);
@@ -1127,7 +1127,8 @@ impl EncryptedFs {
                 })
             })
             .collect();
-
+        
+        // do these futures in parallel and return them
         let mut res = VecDeque::with_capacity(futures.len());
         for f in futures {
             res.push_back(f.await.unwrap());

--- a/tests/linux_mount_setup/mod.rs
+++ b/tests/linux_mount_setup/mod.rs
@@ -46,7 +46,7 @@ impl TestResource {
         Self {
             mount_handle: match mh {
                 Ok(mh) => Some(mh),
-                Err(e) => panic!("Encountered an error mounting {}", e),
+                Err(e) => panic!("Encountered an error mounting {e}"),
             },
             runtime,
         }
@@ -64,8 +64,7 @@ impl Drop for TestResource {
             Ok(_) => println!("Succesfully unmounted"),
             Err(e) => {
                 panic!(
-                    "Something went wrong when unmounting {}.You may need to manually unmount",
-                    e
+                    "Something went wrong when unmounting {e}.You may need to manually unmount"
                 )
             }
         }


### PR DESCRIPTION
## Title    
[#112] Use walkdir for read_dir

## Description

    Move the read part from `read_dir` and `read_dir_plus` to
    `create_directory_entry_iterator` and `create_directory_entry_plus_iterator` and
    use `walkir` instead of `read_dir`.

    Files modified: encryptedfs.rs, Cargo.toml
Fixes # (issue) [#112]



## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

---

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have tested my code on different platforms (if applicable)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added necessary documentation (if appropriate)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


