### PR TITLE
[#25] Check how to perform deleting non-empty directories

### DIFF
--- a/src/mount/linux.rs
+++ b/src/mount/linux.rs
@@ -24,7 +24,7 @@ use fuse3::raw::{Filesystem, MountHandle, Request, Session};
 use fuse3::{Errno, Inode, MountOptions, Result, SetAttr, Timestamp};
 use futures_util::stream::Iter;
 use futures_util::{stream, FutureExt};
-use libc::{EACCES, EEXIST, EFBIG, EIO, EISDIR, ENAMETOOLONG, ENOENT, ENOTDIR, ENOTEMPTY, EPERM};
+use libc::{EACCES, EEXIST, EFBIG, EIO, ENAMETOOLONG, ENOENT, ENOTDIR, ENOTEMPTY, EPERM};
 use shush_rs::{ExposeSecret, SecretString};
 use tracing::{debug, error, instrument, trace, warn};
 use tracing::{info, Level};
@@ -749,7 +749,7 @@ impl Filesystem for EncryptedFsFuse3 {
         {
             error!(err = %err);
             return match err {
-                FsError::NotEmpty => Err(EISDIR.into()),
+                FsError::NotEmpty => Err(ENOTEMPTY.into()),
                 _ => Err(EIO.into()),
             };
         }


### PR DESCRIPTION
## Title

[#25] Check how to perform deleting non-empty directories

## Description

Fix File Explorer deletion by returning ENOTEMPTY. 
Previously mapped FsError:NotEmpty to EISDIR, causing GUI tools to fail.

Fixes #25 

---

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

---

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have tested my code on different platforms (if applicable)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added necessary documentation (if appropriate)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
