### PR TITLE
Add padding to filenames

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1566,6 +1566,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "pad"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ad9b889f1b12e0b9ee24db044b5129150d5eada288edc800f789928dc8c0e3"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1867,6 +1876,8 @@ dependencies = [
  "lru",
  "num-format",
  "okaywal",
+ "once_cell",
+ "pad",
  "rand",
  "rand_chacha",
  "rand_core",
@@ -2546,6 +2557,12 @@ name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ documentation = "https://docs.rs/rencfs"
 exclude = [".github/"]
 
 [dependencies]
+pad = "0.1"
+once_cell = "1.19"
 clap = { version = "4.5.4", features = ["derive", "cargo"] }
 libc = "0.2.153"
 serde = { version = "1.0.197", features = ["derive"] }


### PR DESCRIPTION
## Title

Add padding to filenames to enhance metadata privacy #103

## Description

This PR adds padding to encrypted filenames to ensure they reach a uniform length. This improves privacy by preventing filename length from leaking information about the original file name or its content.

Fixes #103

---

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
---

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code on different platforms (if applicable)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added necessary documentation (if appropriate)
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

