### PR TITLE
feat(#202): Add C/C++ Bindings Support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@ cargo-features = ["profile-rustflags"]
 
 [package]
 name = "rencfs"
+crate-type = ["cdylib", "staticlib", "rlib"]
 description = "WARNING! UNDER ACTIVE DEVELOPMENT. An encrypted file system that is mounted with FUSE on Linux. It can be used to create encrypted directories."
 version = "0.14.11"
 edition = "2021"
@@ -14,6 +15,11 @@ keywords = ["privacy", "filesystem", "encryption", "security", "cryptography"]
 categories = ["cryptography", "filesystem"]
 documentation = "https://docs.rs/rencfs"
 exclude = [".github/"]
+
+[lib]
+name = "rencfs"
+crate-type = ["cdylib", "staticlib", "rlib"]
+path = "src/lib.rs"
 
 [dependencies]
 clap = { version = "4.5.4", features = ["derive", "cargo"] }

--- a/examples/c_binding/main.cpp
+++ b/examples/c_binding/main.cpp
@@ -1,0 +1,57 @@
+#include <iostream>
+#include <vector>
+#include <cstring>
+#include "rencfs.h"
+
+int main() {
+    std::cout << "--- Rencfs C++ Binding Demo ---" << std::endl;
+
+    // 1. Initializare
+    // ATENTIE: Asigura-te ca folderul /tmp/rencfs_test exista sau e un loc unde se poate scrie
+    const char* path = "/tmp/rencfs_cpp_test";
+    const char* pass = "parola_mea_secreta";
+
+    std::cout << "[CPP] Initializing rencfs at " << path << "..." << std::endl;
+    RencfsContext* ctx = rencfs_init(path, pass);
+
+    if (!ctx) {
+        std::cerr << "[CPP] Failed to init rencfs!" << std::endl;
+        return 1;
+    }
+    std::cout << "[CPP] Init success!" << std::endl;
+
+    // 2. Create File
+    uint64_t ino = 0;
+    uint64_t handle = 0;
+    const char* filename = "fisier_secret.txt";
+
+    std::cout << "[CPP] Creating file: " << filename << std::endl;
+    if (rencfs_create_file(ctx, filename, &ino, &handle) != 0) {
+        std::cerr << "[CPP] Failed to create file!" << std::endl;
+        rencfs_free(ctx);
+        return 1;
+    }
+    std::cout << "[CPP] Created! Inode: " << ino << ", Handle: " << handle << std::endl;
+
+    // 3. Write Data
+    const char* message = "Salut din C++ catre Rust Encrypted FS!";
+    size_t len = strlen(message);
+    std::cout << "[CPP] Writing: " << message << std::endl;
+
+    int written = rencfs_write(ctx, ino, handle, (const unsigned char*)message, len, 0);
+    std::cout << "[CPP] Bytes written: " << written << std::endl;
+
+    // 4. Close (flush)
+    std::cout << "[CPP] Closing file (flush)..." << std::endl;
+    rencfs_close(ctx, handle);
+
+    // 5. Open/Read (pentru simplitate in demo, presupunem ca il citim cu un handle nou sau ne-am baza pe open,
+    // dar aici doar inchidem contextul pentru a arata cleanup-ul).
+
+    // 6. Cleanup
+    std::cout << "[CPP] Freeing context..." << std::endl;
+    rencfs_free(ctx);
+
+    std::cout << "[CPP] Done." << std::endl;
+    return 0;
+}

--- a/examples/c_binding/main.cpp
+++ b/examples/c_binding/main.cpp
@@ -82,6 +82,27 @@ int main() {
     std::cout << "[CPP] Freeing context..." << std::endl;
     rencfs_free(ctx);
 
+	// 10. Test CHANGE PASSWORD
+    std::cout << "[CPP] Changing password..." << std::endl;
+    const char* new_pass = "parola_noua_super_secreta";
+    
+    if (rencfs_change_password(path, pass, new_pass) == 0) {
+        std::cout << "[CPP] Password changed successfully!" << std::endl;
+    } else {
+        std::cerr << "[CPP] Change password failed!" << std::endl;
+        return 1;
+    }
+
+    // 11. Re-Init cu noua parola (Verificare)
+    std::cout << "[CPP] Re-initializing with NEW password..." << std::endl;
+    RencfsContext* ctx2 = rencfs_init(path, new_pass);
+    if (ctx2) {
+        std::cout << "[CPP] Auth with new password successful!" << std::endl;
+        rencfs_free(ctx2);
+    } else {
+        std::cerr << "[CPP] Auth with new password FAILED!" << std::endl;
+    }
+
     std::cout << "[CPP] Done." << std::endl;
     return 0;
 }

--- a/examples/c_binding/main.cpp
+++ b/examples/c_binding/main.cpp
@@ -62,6 +62,28 @@ int main() {
         std::cerr << "[CPP] Rename failed!" << std::endl;
     }
 
+	// --- TEST LS (LIST FILES) ---
+    std::cout << "\n[CPP] --- Listing Root Directory ---" << std::endl;
+    // Deschidem directorul root (inode 1)
+    RencfsDirIterator* iter = rencfs_opendir(ctx, 1);
+    
+    if (iter) {
+        char name_buf[256];
+        uint64_t entry_ino;
+        unsigned char entry_type;
+        
+        // Bucla while care citeste cat timp rencfs_readdir returneaza 1
+        while (rencfs_readdir(iter, name_buf, sizeof(name_buf), &entry_ino, &entry_type) == 1) {
+            std::string type_str = (entry_type == 1) ? "[DIR] " : "[FILE]";
+            std::cout << "  " << type_str << " " << name_buf << " (ino: " << entry_ino << ")" << std::endl;
+        }
+        
+        rencfs_closedir(iter);
+        std::cout << "[CPP] --- End Listing ---\n" << std::endl;
+    } else {
+        std::cerr << "[CPP] Failed to open directory!" << std::endl;
+    }
+
     // 7. Test UNLINK (Stergem fisierul redenumit)
     std::cout << "[CPP] Deleting file '" << new_filename << "'..." << std::endl;
     if (rencfs_unlink(ctx, 1, new_filename) == 0) {

--- a/examples/c_binding/main.cpp
+++ b/examples/c_binding/main.cpp
@@ -7,7 +7,6 @@ int main() {
     std::cout << "--- Rencfs C++ Binding Demo ---" << std::endl;
 
     // 1. Initializare
-    // ATENTIE: Asigura-te ca folderul /tmp/rencfs_test exista sau e un loc unde se poate scrie
     const char* path = "/tmp/rencfs_cpp_test";
     const char* pass = "parola_mea_secreta";
 
@@ -45,10 +44,41 @@ int main() {
     std::cout << "[CPP] Closing file (flush)..." << std::endl;
     rencfs_close(ctx, handle);
 
-    // 5. Open/Read (pentru simplitate in demo, presupunem ca il citim cu un handle nou sau ne-am baza pe open,
-    // dar aici doar inchidem contextul pentru a arata cleanup-ul).
+    // 5. Test MKDIR (Facem folderul pe care il vom sterge la final)
+    uint64_t dir_ino = 0;
+    std::cout << "[CPP] Creating directory 'my_secrets'..." << std::endl;
+    if (rencfs_mkdir(ctx, 1, "my_secrets", &dir_ino) == 0) {
+        std::cout << "[CPP] Directory created! Inode: " << dir_ino << std::endl;
+    } else {
+        std::cerr << "[CPP] Mkdir failed!" << std::endl;
+    }
 
-    // 6. Cleanup
+    // 6. Test RENAME
+    const char* new_filename = "redenumit_secret.txt";
+    std::cout << "[CPP] Renaming '" << filename << "' to '" << new_filename << "'..." << std::endl;
+    if (rencfs_rename(ctx, 1, filename, 1, new_filename) == 0) {
+        std::cout << "[CPP] Rename success!" << std::endl;
+    } else {
+        std::cerr << "[CPP] Rename failed!" << std::endl;
+    }
+
+    // 7. Test UNLINK (Stergem fisierul redenumit)
+    std::cout << "[CPP] Deleting file '" << new_filename << "'..." << std::endl;
+    if (rencfs_unlink(ctx, 1, new_filename) == 0) {
+        std::cout << "[CPP] File deleted successfully!" << std::endl;
+    } else {
+        std::cerr << "[CPP] Unlink failed!" << std::endl;
+    }
+
+    // 8. Test RMDIR (Stergem directorul creat la pasul 5)
+    std::cout << "[CPP] Removing directory 'my_secrets'..." << std::endl;
+    if (rencfs_rmdir(ctx, 1, "my_secrets") == 0) {
+        std::cout << "[CPP] Rmdir success!" << std::endl;
+    } else {
+        std::cerr << "[CPP] Rmdir failed!" << std::endl;
+    }
+
+    // 9. Cleanup
     std::cout << "[CPP] Freeing context..." << std::endl;
     rencfs_free(ctx);
 

--- a/rencfs.h
+++ b/rencfs.h
@@ -30,6 +30,10 @@ int rencfs_rmdir(RencfsContext* ctx, uint64_t parent_ino, const char* filename);
 
 // Redenumeste/Muta un fisier.
 int rencfs_rename(RencfsContext* ctx, uint64_t parent, const char* old_name, uint64_t new_parent, const char* new_name);
+
+// Schimba parola. Nu necesita context (lucreaza direct pe path).
+int rencfs_change_password(const char* base_path, const char* old_pass, const char* new_pass);
+
 // Scrie in fisier.
 int rencfs_write(RencfsContext* ctx, uint64_t ino, uint64_t handle, const unsigned char* buf, size_t len, uint64_t offset);
 

--- a/rencfs.h
+++ b/rencfs.h
@@ -1,0 +1,35 @@
+#ifndef RENCFS_H
+#define RENCFS_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Pointer opac catre structura Rust
+typedef struct RencfsContext RencfsContext;
+
+// Initializeaza sistemul. Returneaza NULL la eroare.
+RencfsContext* rencfs_init(const char* base_path, const char* password);
+
+// Elibereaza memoria.
+void rencfs_free(RencfsContext* ctx);
+
+// Creeaza un fisier. Returneaza 0 la succes.
+int rencfs_create_file(RencfsContext* ctx, const char* filename, uint64_t* out_ino, uint64_t* out_handle);
+
+// Scrie in fisier.
+int rencfs_write(RencfsContext* ctx, uint64_t ino, uint64_t handle, const unsigned char* buf, size_t len, uint64_t offset);
+
+// Citeste din fisier.
+int rencfs_read(RencfsContext* ctx, uint64_t ino, uint64_t handle, unsigned char* buf, size_t len, uint64_t offset);
+
+// Inchide fisierul.
+int rencfs_close(RencfsContext* ctx, uint64_t handle);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/rencfs.h
+++ b/rencfs.h
@@ -34,6 +34,21 @@ int rencfs_rename(RencfsContext* ctx, uint64_t parent, const char* old_name, uin
 // Schimba parola. Nu necesita context (lucreaza direct pe path).
 int rencfs_change_password(const char* base_path, const char* old_pass, const char* new_pass);
 
+// --- Directory Listing ---
+
+typedef struct RencfsDirIterator RencfsDirIterator;
+
+// Deschide director. Returneaza pointer sau NULL.
+RencfsDirIterator* rencfs_opendir(RencfsContext* ctx, uint64_t ino);
+
+// Citeste urmatorul element.
+// Return: 1 (OK), 0 (Done), -1 (Error)
+// out_type: 1 = Directory, 2 = Regular File
+int rencfs_readdir(RencfsDirIterator* iter, char* out_name, size_t name_len, uint64_t* out_ino, unsigned char* out_type);
+
+// Inchide iteratorul.
+void rencfs_closedir(RencfsDirIterator* iter);
+
 // Scrie in fisier.
 int rencfs_write(RencfsContext* ctx, uint64_t ino, uint64_t handle, const unsigned char* buf, size_t len, uint64_t offset);
 

--- a/rencfs.h
+++ b/rencfs.h
@@ -19,6 +19,17 @@ void rencfs_free(RencfsContext* ctx);
 // Creeaza un fisier. Returneaza 0 la succes.
 int rencfs_create_file(RencfsContext* ctx, const char* filename, uint64_t* out_ino, uint64_t* out_handle);
 
+// Creeaza un director. Returneaza 0 la succes.
+int rencfs_mkdir(RencfsContext* ctx, uint64_t parent_ino, const char* filename, uint64_t* out_ino);
+
+// Sterge un fisier.
+int rencfs_unlink(RencfsContext* ctx, uint64_t parent_ino, const char* filename);
+
+// Sterge un director (rmdir). Returneaza 0 la succes.
+int rencfs_rmdir(RencfsContext* ctx, uint64_t parent_ino, const char* filename);
+
+// Redenumeste/Muta un fisier.
+int rencfs_rename(RencfsContext* ctx, uint64_t parent, const char* old_name, uint64_t new_parent, const char* new_name);
 // Scrie in fisier.
 int rencfs_write(RencfsContext* ctx, uint64_t ino, uint64_t handle, const unsigned char* buf, size_t len, uint64_t offset);
 

--- a/src/c_api.rs
+++ b/src/c_api.rs
@@ -1,0 +1,235 @@
+use std::ffi::CStr;
+use std::os::raw::{c_char, c_int, c_uchar, c_ulonglong};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::ptr;
+use tokio::runtime::Runtime;
+use shush_rs::SecretString;
+
+use crate::encryptedfs::{EncryptedFs, PasswordProvider, CreateFileAttr, FileType, ROOT_INODE};
+use crate::crypto::Cipher;
+
+// --- Structuri Ajutătoare ---
+
+// Aceasta este structura opacă pe care o va ține C++ (void*)
+pub struct RencfsContext {
+    rt: Runtime,
+    fs: Arc<EncryptedFs>,
+}
+
+// Avem nevoie de un provider simplu de parolă pentru init
+struct SimplePasswordProvider {
+    password: SecretString,
+}
+
+impl PasswordProvider for SimplePasswordProvider {
+    fn get_password(&self) -> Option<SecretString> {
+        Some(self.password.clone())
+    }
+}
+
+// --- API-ul C (FFI) ---
+
+/// Inițializează filesystem-ul.
+/// Returnează un pointer către context (sau NULL dacă eșuează).
+///
+/// # Safety
+/// Pointers `base_path` and `password` must be valid, null-terminated C strings.
+/// The caller is responsible for freeing the returned pointer using `rencfs_free`.
+#[no_mangle]
+pub unsafe extern "C" fn rencfs_init(
+    base_path: *const c_char,
+    password: *const c_char,
+) -> *mut RencfsContext {
+    if base_path.is_null() || password.is_null() {
+        return ptr::null_mut();
+    }
+
+    // Conversie C strings -> Rust
+    let c_path = CStr::from_ptr(base_path);
+    let path_str = match c_path.to_str() {
+        Ok(s) => s,
+        Err(_) => return ptr::null_mut(),
+    };
+    let path_buf = PathBuf::from(path_str);
+
+    let c_pass = CStr::from_ptr(password);
+    let pass_str = match c_pass.to_str() {
+        Ok(s) => s,
+        Err(_) => return ptr::null_mut(),
+    };
+    let secret_pass = SecretString::new(Box::new(pass_str.to_string()));
+
+    // Pornim Runtime-ul Tokio
+    let rt = match Runtime::new() {
+        Ok(r) => r,
+        Err(_) => return ptr::null_mut(),
+    };
+
+    // Inițializăm FS-ul (Async executat sincron)
+    let fs_result = rt.block_on(async {
+        let provider = Box::new(SimplePasswordProvider { password: secret_pass });
+        // Folosim ChaCha20Poly1305 ca default pentru demo
+        EncryptedFs::new(path_buf, provider, Cipher::ChaCha20Poly1305, false).await
+    });
+
+    match fs_result {
+        Ok(fs) => {
+            let context = Box::new(RencfsContext { rt, fs });
+            Box::into_raw(context)
+        }
+        Err(e) => {
+            eprintln!("Eroare la init rencfs: {:?}", e);
+            ptr::null_mut()
+        }
+    }
+}
+
+/// Eliberează memoria contextului.
+///
+/// # Safety
+/// `ctx` must be a valid pointer created by `rencfs_init`.
+/// After calling this, `ctx` becomes invalid.
+#[no_mangle]
+pub unsafe extern "C" fn rencfs_free(ctx: *mut RencfsContext) {
+    if !ctx.is_null() {
+        // Rust va face "drop" automat când pointerul revine în Box
+        let _ = Box::from_raw(ctx);
+        println!("Rencfs context eliberat.");
+    }
+}
+
+/// Creează un fișier nou în root.
+/// Returnează 0 la succes, -1 la eroare.
+/// Completează out_ino și out_handle.
+///
+/// # Safety
+/// `ctx` must be a valid pointer.
+/// `filename` must be a valid null-terminated C string.
+/// `out_ino` and `out_handle` must be valid pointers to writeable memory.
+#[no_mangle]
+pub unsafe extern "C" fn rencfs_create_file(
+    ctx: *mut RencfsContext,
+    filename: *const c_char,
+    out_ino: *mut c_ulonglong,
+    out_handle: *mut c_ulonglong,
+) -> c_int {
+    let context = &mut *ctx;
+    let c_name = CStr::from_ptr(filename);
+    let name_str = match c_name.to_str() {
+        Ok(s) => s,
+        Err(_) => return -1,
+    };
+    let secret_name = SecretString::new(Box::new(name_str.to_string()));
+
+    // Configurare atribute default (RegularFile, permisiuni 644)
+    let attr = CreateFileAttr {
+        kind: FileType::RegularFile,
+        perm: 0o644,
+        uid: 0,
+        gid: 0,
+        rdev: 0,
+        flags: 0,
+    };
+
+    let result = context.rt.block_on(async {
+        context.fs.create(ROOT_INODE, &secret_name, attr, true, true).await
+    });
+
+    match result {
+        Ok((handle, file_attr)) => {
+            *out_ino = file_attr.ino;
+            *out_handle = handle;
+            0
+        }
+        Err(e) => {
+            eprintln!("Eroare create file: {:?}", e);
+            -1
+        }
+    }
+}
+
+/// Scrie date într-un fișier deschis.
+/// Returnează numărul de bytes scriși sau -1 la eroare.
+///
+/// # Safety
+/// `ctx` must be a valid pointer.
+/// `buf` must be a valid pointer to a byte array of at least `len` size.
+#[no_mangle]
+pub unsafe extern "C" fn rencfs_write(
+    ctx: *mut RencfsContext,
+    ino: c_ulonglong,
+    handle: c_ulonglong,
+    buf: *const c_uchar,
+    len: usize,
+    offset: c_ulonglong,
+) -> c_int {
+    let context = &mut *ctx;
+    let data_slice = std::slice::from_raw_parts(buf, len);
+
+    let result = context.rt.block_on(async {
+        context.fs.write(ino, offset, data_slice, handle).await
+    });
+
+    match result {
+        Ok(bytes_written) => bytes_written as c_int,
+        Err(e) => {
+            eprintln!("Eroare write: {:?}", e);
+            -1
+        }
+    }
+}
+
+/// Citește date dintr-un fișier.
+/// Returnează numărul de bytes citiți sau -1 la eroare.
+///
+/// # Safety
+/// `ctx` must be a valid pointer.
+/// `buf` must be a valid pointer to a writeable buffer of at least `len` size.
+#[no_mangle]
+pub unsafe extern "C" fn rencfs_read(
+    ctx: *mut RencfsContext,
+    ino: c_ulonglong,
+    handle: c_ulonglong,
+    buf: *mut c_uchar,
+    len: usize,
+    offset: c_ulonglong,
+) -> c_int {
+    let context = &mut *ctx;
+    let data_slice = std::slice::from_raw_parts_mut(buf, len);
+
+    let result = context.rt.block_on(async {
+        context.fs.read(ino, offset, data_slice, handle).await
+    });
+
+    match result {
+        Ok(bytes_read) => bytes_read as c_int,
+        Err(e) => {
+            eprintln!("Eroare read: {:?}", e);
+            -1
+        }
+    }
+}
+
+/// Închide un handle (release).
+///
+/// # Safety
+/// `ctx` must be a valid pointer.
+#[no_mangle]
+pub unsafe extern "C" fn rencfs_close(
+    ctx: *mut RencfsContext,
+    handle: c_ulonglong,
+) -> c_int {
+    let context = &mut *ctx;
+    let result = context.rt.block_on(async {
+        context.fs.release(handle).await
+    });
+
+    match result {
+        Ok(_) => 0,
+        Err(e) => {
+            eprintln!("Eroare close: {:?}", e);
+            -1
+        }
+    }
+}

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 use shush_rs::{ExposeSecret, SecretString, SecretVec};
 use strum_macros::{Display, EnumIter, EnumString};
 use thiserror::Error;
-use tracing::{debug, error, instrument};
+use tracing::{debug, instrument};
 use write::CryptoInnerWriter;
 
 use crate::crypto::read::{CryptoRead, CryptoReadSeek, RingCryptoRead};

--- a/src/crypto/write.rs
+++ b/src/crypto/write.rs
@@ -382,7 +382,7 @@ impl<W: CryptoInnerWriter + Send + Sync> Seek for RingCryptoWrite<W> {
                 self.block_index = 0;
                 self.decrypt_block()?;
             }
-            let at_full_block_end = self.pos() % self.plaintext_block_size as u64 == 0
+            let at_full_block_end = self.pos().is_multiple_of(self.plaintext_block_size as u64)
                 && self.buf.pos_write() == self.buf.available();
             if self.buf.available() == 0
                 // this checks if we are at the end of the current block,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,6 +290,7 @@ use std::sync::LazyLock;
 
 pub mod arc_hashmap;
 pub mod async_util;
+pub mod c_api;
 pub mod crypto;
 pub mod encryptedfs;
 pub mod expire_value;


### PR DESCRIPTION
**Title:** feat(#202): Add C/C++ Bindings Support

**Description:**
Implemented C bindings for the `rencfs` library to allow integration with C/C++ applications, addressing issue #202. This introduces a FFI (Foreign Function Interface) layer that exposes core filesystem operations.

**Changes:**
- Added `src/c_api.rs`: Contains the FFI shim layer bridging sync C calls to async Rust `tokio` runtime.
- Modified `Cargo.toml`: Added `cdylib` and `staticlib` crate types to generate `.so` and `.a` libraries.
- Added `rencfs.h`: C header file defining the API.
- Added `examples/c_binding/main.cpp`: A comprehensive demo application testing all implemented features.

**Implemented Operations:**
- **Core:** Init, Free, Create File, Read, Write, Close.
- **Directory Ops:** Mkdir, Rmdir, Rename, Unlink.
- **Listing:** Directory iteration (`opendir`, `readdir`, `closedir`) using stateful iterators.
- **Auth:** Change Password.

**Fixes # (issue):** 202

**Type of change:**
[ ] Bug fix
[x] New feature (non-breaking change which adds functionality)

**Checklist:**
[x] New and existing unit tests pass locally with my changes
[x] I have performed a self-review of my code
[x] My changes generate no new warnings (handled via FFI safety blocks)