### PR TITLE
Add basic WinFSP support on Windows (#3)

### DIFF
--- a/.github/workflows/build_and_tests.yaml
+++ b/.github/workflows/build_and_tests.yaml
@@ -25,7 +25,6 @@ jobs:
       cancel-in-progress: true
     name: build and test
     uses: ./.github/workflows/build_and_tests_reusable.yaml
-    secrets: inherit
 
   package:
     needs: [ version, build_and_test ]

--- a/.github/workflows/build_and_tests.yaml
+++ b/.github/workflows/build_and_tests.yaml
@@ -24,7 +24,7 @@ jobs:
       group: build-${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
     name: build and test
-    uses: xoriors/rencfs/.github/workflows/build_and_tests_reusable.yaml@main
+    uses: ./.github/workflows/build_and_tests_reusable.yaml
     secrets: inherit
 
   package:

--- a/.github/workflows/build_and_tests_reusable.yaml
+++ b/.github/workflows/build_and_tests_reusable.yaml
@@ -39,6 +39,26 @@ jobs:
           cargo install cargo-aur
           cargo install cargo-generate-rpm          
 
+      - name: install WinFSP
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          $msi = Join-Path $env:RUNNER_TEMP 'winfsp-2.1.25156.msi'
+          Invoke-WebRequest `
+            -Uri 'https://github.com/winfsp/winfsp/releases/download/v2.1/winfsp-2.1.25156.msi' `
+            -OutFile $msi
+          $expected = '073A70E00F77423E34BED98B86E600DEF93393BA5822204FAC57A29324DB9F7A'
+          $actual = (Get-FileHash -Algorithm SHA256 $msi).Hash
+          if ($actual -ne $expected) {
+            throw "WinFSP MSI checksum mismatch: $actual"
+          }
+          $installer = Start-Process msiexec.exe `
+            -ArgumentList @('/i', $msi, '/qn', '/norestart') `
+            -Wait -PassThru -WindowStyle Hidden
+          if ($installer.ExitCode -notin @(0, 3010)) {
+            throw "WinFSP installation failed with exit code $($installer.ExitCode)"
+          }
+
       - name: build
         run: |
           cargo build --all-targets --all-features
@@ -64,6 +84,10 @@ jobs:
       - name: tests
         if: matrix.os != 'windows-latest'
         run: cargo test --release --all --all-features -- --skip keyring
+
+      - name: Windows WinFSP adapter tests
+        if: matrix.os == 'windows-latest'
+        run: cargo test --release --lib mount::windows::tests
 
       - name: bench
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/build_and_tests_reusable.yaml
+++ b/.github/workflows/build_and_tests_reusable.yaml
@@ -89,6 +89,65 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: cargo test --release --lib mount::windows::tests
 
+      - name: Windows WinFSP mount smoke test
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          $dataDir = Join-Path $env:RUNNER_TEMP 'rencfs-smoke-data'
+          $stdout = Join-Path $env:RUNNER_TEMP 'rencfs-smoke.stdout.log'
+          $stderr = Join-Path $env:RUNNER_TEMP 'rencfs-smoke.stderr.log'
+          $env:RENCFS_PASSWORD = 'ci-only-smoke-test-password'
+          $arguments = @(
+            'mount',
+            '--mount-point', 'R:',
+            '--data-dir', "`"$dataDir`"",
+            '--log-level', 'WARN'
+          )
+          $rencfsProcess = Start-Process `
+            -FilePath '.\target\release\rencfs.exe' `
+            -ArgumentList $arguments `
+            -RedirectStandardOutput $stdout `
+            -RedirectStandardError $stderr `
+            -PassThru -WindowStyle Hidden
+          try {
+            $mounted = $false
+            for ($attempt = 0; $attempt -lt 60; $attempt++) {
+              if ($rencfsProcess.HasExited) {
+                throw "rencfs exited before mounting (exit $($rencfsProcess.ExitCode))"
+              }
+              if (Test-Path -LiteralPath 'R:\') {
+                $mounted = $true
+                break
+              }
+              Start-Sleep -Milliseconds 500
+            }
+            if (-not $mounted) {
+              throw 'WinFSP mount R: did not appear within 30 seconds'
+            }
+
+            New-Item -ItemType Directory -Path 'R:\smoke' | Out-Null
+            $payload = 'WinFSP end-to-end smoke test'
+            [System.IO.File]::WriteAllText('R:\smoke\hello.txt', $payload)
+            $actual = [System.IO.File]::ReadAllText('R:\smoke\hello.txt')
+            if ($actual -ne $payload) {
+              throw "mounted file contents differ: $actual"
+            }
+            Move-Item -LiteralPath 'R:\smoke\hello.txt' -Destination 'R:\smoke\renamed.txt'
+            Remove-Item -LiteralPath 'R:\smoke\renamed.txt'
+            Remove-Item -LiteralPath 'R:\smoke'
+          }
+          catch {
+            if (Test-Path -LiteralPath $stdout) { Get-Content -LiteralPath $stdout }
+            if (Test-Path -LiteralPath $stderr) { Get-Content -LiteralPath $stderr }
+            throw
+          }
+          finally {
+            if (-not $rencfsProcess.HasExited) {
+              Stop-Process -Id $rencfsProcess.Id -Force
+              $rencfsProcess.WaitForExit()
+            }
+          }
+
       - name: bench
         if: matrix.os == 'ubuntu-latest'
         run: cargo bench --workspace --all-targets --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,6 +44,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,6 +541,19 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "ciborium"
@@ -1168,6 +1190,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1844,6 +1890,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "registry"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "515143bd3c240fd5a47002a552fd7eba71acf8cd3cf7472e5ec392cda2ed3d90"
+dependencies = [
+ "bitflags 1.3.2",
+ "log",
+ "thiserror 1.0.64",
+ "utfx",
+ "windows",
+]
+
+[[package]]
 name = "rencfs"
 version = "0.14.11"
 dependencies = [
@@ -1887,6 +1946,8 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "tracing-test",
+ "winfsp_wrs",
+ "winfsp_wrs_build",
 ]
 
 [[package]]
@@ -2135,9 +2196,8 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shush-rs"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de8f82d4a4085f9ea4ab8d493e6e62ab871b2bf446d4d90633b58ca400aedff"
+version = "0.1.11"
+source = "git+https://github.com/qtcqtc/shush-rs?rev=4d4a7372a684b9c455eaae499e3385bfbd25515f#4d4a7372a684b9c455eaae499e3385bfbd25515f"
 dependencies = [
  "errno",
  "libc",
@@ -2559,6 +2619,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "utfx"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "133bf74f01486773317ddfcde8e2e20d2933cc3b68ab797e5d718bef996a81de"
+
+[[package]]
 name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2670,6 +2736,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2699,6 +2771,129 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
+ "windows-link",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -2847,6 +3042,33 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winfsp_wrs"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3094fd0a4875434d3d7a2ddb273d382eece18243e14a139c12787fb3e9fb1062"
+dependencies = [
+ "chrono",
+ "widestring",
+ "windows-sys 0.52.0",
+ "winfsp_wrs_sys",
+]
+
+[[package]]
+name = "winfsp_wrs_build"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9548e1180e2778ccb318107599704c2e69407e286d4a98a0649ec85440ac2e76"
+
+[[package]]
+name = "winfsp_wrs_sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c700c432cdb562e78eee5ba72ee103d462b356a97993f78070ab409ad2c4cc5"
+dependencies = [
+ "registry",
+]
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1946,6 +1946,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "tracing-test",
+ "windows-sys 0.52.0",
  "winfsp_wrs",
  "winfsp_wrs_build",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1948,7 +1948,6 @@ dependencies = [
  "tracing-test",
  "windows-sys 0.52.0",
  "winfsp_wrs",
- "winfsp_wrs_build",
 ]
 
 [[package]]
@@ -3055,12 +3054,6 @@ dependencies = [
  "windows-sys 0.52.0",
  "winfsp_wrs_sys",
 ]
-
-[[package]]
-name = "winfsp_wrs_build"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9548e1180e2778ccb318107599704c2e69407e286d4a98a0649ec85440ac2e76"
 
 [[package]]
 name = "winfsp_wrs_sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,12 @@ fuse3 = { version = "0.8.1", features = ["tokio-runtime", "unprivileged"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winfsp_wrs = "0.4.1"
+windows-sys = { version = "0.52.0", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Security_Authorization",
+    "Win32_System_Threading",
+] }
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
 winfsp_wrs_build = "0.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,11 +56,17 @@ blake3 = "=0.1.3"
 thread_local = "1.1.8"
 subtle = "2.6.1"
 bon = "3.3.0"
-shush-rs = "0.1.10"
+shush-rs = { version = "0.1.11", git = "https://github.com/qtcqtc/shush-rs", rev = "4d4a7372a684b9c455eaae499e3385bfbd25515f" }
 criterion = { version = "0.5.1", features = ["html_reports"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 fuse3 = { version = "0.8.1", features = ["tokio-runtime", "unprivileged"] }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+winfsp_wrs = "0.4.1"
+
+[target.'cfg(target_os = "windows")'.build-dependencies]
+winfsp_wrs_build = "0.4.1"
 
 [[bench]]
 name = "crypto_read"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,9 +71,6 @@ windows-sys = { version = "0.52.0", features = [
     "Win32_System_Threading",
 ] }
 
-[target.'cfg(target_os = "windows")'.build-dependencies]
-winfsp_wrs_build = "0.4.1"
-
 [[bench]]
 name = "crypto_read"
 harness = false

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,18 @@
 fn main() {
-    if std::env::var_os("CARGO_CFG_TARGET_OS").is_some_and(|target| target == "windows") {
-        #[cfg(target_os = "windows")]
-        winfsp_wrs_build::build();
+    if !std::env::var_os("CARGO_CFG_TARGET_OS").is_some_and(|target| target == "windows")
+        || !std::env::var_os("CARGO_CFG_TARGET_ENV").is_some_and(|target| target == "msvc")
+    {
+        return;
     }
+
+    let dll = match std::env::var("CARGO_CFG_TARGET_ARCH").as_deref() {
+        Ok("x86_64") => "winfsp-x64.dll",
+        Ok("x86") => "winfsp-x86.dll",
+        Ok("aarch64") => "winfsp-a64.dll",
+        Ok(arch) => panic!("unsupported Windows architecture: {}", arch),
+        Err(error) => panic!("CARGO_CFG_TARGET_ARCH is not set: {}", error),
+    };
+
+    println!("cargo:rustc-link-lib=dylib=delayimp");
+    println!("cargo:rustc-link-arg=/DELAYLOAD:{dll}");
 }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    #[cfg(target_os = "windows")]
+    winfsp_wrs_build::build();
+}

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,6 @@
 fn main() {
-    #[cfg(target_os = "windows")]
-    winfsp_wrs_build::build();
+    if std::env::var_os("CARGO_CFG_TARGET_OS").is_some_and(|target| target == "windows") {
+        #[cfg(target_os = "windows")]
+        winfsp_wrs_build::build();
+    }
 }

--- a/docs/readme/Usage.md
+++ b/docs/readme/Usage.md
@@ -74,8 +74,7 @@ For the library, you can follow the [documentation](https://docs.rs/rencfs/lates
 
 ### Dependencies
 
-To use the encrypted file system, you need to have FUSE installed on your system. You can install it by running the
-following command (or based on your distribution).
+On Linux, install FUSE using your distribution's package manager.
 
 Arch
 
@@ -88,6 +87,9 @@ Ubuntu
 ```bash
 sudo apt-get update && sudo apt-get -y install fuse3
 ```
+
+On Windows, install [WinFSP 2.1](https://github.com/winfsp/winfsp/releases/tag/v2.1).
+The WinFSP driver must be installed before building or running `rencfs`.
 
 ### Install from AUR
 
@@ -113,7 +115,13 @@ A basic example of how to use the encrypted file system is shown below
 rencfs mount --mount-point MOUNT_POINT --data-dir DATA_DIR
 ```
 
-- `MOUNT_POINT` act as a client, and mount FUSE at the given path
+On Windows, the mount point can be a free drive letter:
+
+```powershell
+rencfs mount --mount-point R: --data-dir C:\Users\me\rencfs-data
+```
+
+- `MOUNT_POINT` acts as a client and mounts FUSE on Linux or WinFSP on Windows
 - `DATA_DIR` where to store the encrypted data
   with the sync provider. But it needs to be on the same filesystem as the data-dir
 

--- a/examples/internal_ring_speed.rs
+++ b/examples/internal_ring_speed.rs
@@ -80,14 +80,10 @@ fn main() -> io::Result<()> {
         let len = {
             let mut pos = 0;
             loop {
-                match input.read(&mut buffer[pos..]) {
-                    Ok(read) => {
-                        pos += read;
-                        if read == 0 {
-                            break;
-                        }
-                    }
-                    Err(err) => return Err(err),
+                let read = input.read(&mut buffer[pos..])?;
+                pos += read;
+                if read == 0 {
+                    break;
                 }
             }
             pos
@@ -139,14 +135,10 @@ fn main() -> io::Result<()> {
         let len = {
             let mut pos = 0;
             loop {
-                match input.read(&mut buffer[pos..]) {
-                    Ok(read) => {
-                        pos += read;
-                        if read == 0 {
-                            break;
-                        }
-                    }
-                    Err(err) => return Err(err),
+                let read = input.read(&mut buffer[pos..])?;
+                pos += read;
+                if read == 0 {
+                    break;
                 }
             }
             pos

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,4 +1,4 @@
-use std::fs::{File, OpenOptions};
+use std::fs::OpenOptions;
 use std::io;
 use std::io::{Read, Seek, Write};
 use std::num::ParseIntError;
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 use shush_rs::{ExposeSecret, SecretString, SecretVec};
 use strum_macros::{Display, EnumIter, EnumString};
 use thiserror::Error;
-use tracing::{debug, error, instrument};
+use tracing::{debug, instrument};
 use write::CryptoInnerWriter;
 
 use crate::crypto::read::{CryptoRead, CryptoReadSeek, RingCryptoRead};
@@ -217,7 +217,9 @@ pub fn decrypt(s: &str, cipher: Cipher, key: &SecretVec<u8>) -> Result<SecretStr
 
 #[allow(clippy::missing_errors_doc)]
 pub fn decrypt_file_name(name: &str, cipher: Cipher, key: &SecretVec<u8>) -> Result<SecretString> {
-    let name = String::from(name).replace('|', "/");
+    // `|` is the original Unix-safe escape. `-` is emitted on Windows because
+    // it is not part of standard Base64 and is valid in Windows file names.
+    let name = String::from(name).replace(['|', '-'], "/");
     decrypt(&name, cipher, key)
 }
 
@@ -242,13 +244,20 @@ pub fn encrypt_file_name(
     let secret_string = name.expose_secret();
 
     match secret_string.as_str() {
-        "$." | "$.." => Ok(secret_string.clone()),
-        "." | ".." => Ok(format!("${secret_string}")),
+        "$." | "." => Ok(dot_entry_storage_name().to_owned()),
+        "$.." | ".." => Ok(dot_dot_entry_storage_name().to_owned()),
         _ => {
             let secret = SecretString::from_str(&secret_string)
                 .map_err(|err| Error::GenericString(err.to_string()))?;
             let mut encrypted = encrypt(&secret, cipher, key)?;
-            encrypted = encrypted.replace('/', "|");
+            #[cfg(target_os = "windows")]
+            {
+                encrypted = encrypted.replace('/', "-");
+            }
+            #[cfg(not(target_os = "windows"))]
+            {
+                encrypted = encrypted.replace('/', "|");
+            }
 
             Ok(encrypted)
         }
@@ -258,13 +267,39 @@ pub fn encrypt_file_name(
 #[allow(clippy::missing_errors_doc)]
 #[must_use]
 pub fn hash_file_name(name: &SecretString) -> String {
-    if *name.expose_secret() == "$." || *name.expose_secret() == "$.." {
-        name.expose_secret().clone()
-    } else if *name.expose_secret() == "." || *name.expose_secret() == ".." {
-        format!("${}", name.expose_secret())
-    } else {
-        hex::encode(hash_secret_string(name))
+    match name.expose_secret().as_str() {
+        "$." | "." => dot_entry_storage_name().to_owned(),
+        "$.." | ".." => dot_dot_entry_storage_name().to_owned(),
+        _ => hex::encode(hash_secret_string(name)),
     }
+}
+
+#[must_use]
+pub(crate) const fn dot_entry_storage_name() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "$dot"
+    } else {
+        "$."
+    }
+}
+
+#[must_use]
+pub(crate) const fn dot_dot_entry_storage_name() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "$dotdot"
+    } else {
+        "$.."
+    }
+}
+
+#[must_use]
+pub(crate) fn is_dot_entry_storage_name(name: &str) -> bool {
+    matches!(name, "$." | "$dot")
+}
+
+#[must_use]
+pub(crate) fn is_dot_dot_entry_storage_name(name: &str) -> bool {
+    matches!(name, "$.." | "$dotdot")
 }
 
 #[must_use]
@@ -376,7 +411,7 @@ where
     let mut file = fs_util::open_atomic_write(file)?;
     file = serialize_encrypt_into(file, value, cipher, key)?;
     file.commit()?;
-    File::open(parent)?.sync_all()?;
+    fs_util::sync_directory(parent)?;
     Ok(())
 }
 
@@ -549,27 +584,23 @@ mod tests {
 
     #[test]
     fn test_hash_file_name_special_cases() {
-        let expected = "$.".to_owned();
-        let name = SecretString::new(Box::new(expected.clone()));
+        let name = SecretString::new(Box::new("$.".to_owned()));
         let result = hash_file_name(&name);
-        assert_eq!(result, expected);
+        assert_eq!(result, dot_entry_storage_name());
 
-        let expected = "$..".to_owned();
-        let name = SecretString::new(Box::new(expected.clone()));
+        let name = SecretString::new(Box::new("$..".to_owned()));
         let result = hash_file_name(&name);
-        assert_eq!(result, expected);
+        assert_eq!(result, dot_dot_entry_storage_name());
 
         let input = ".".to_owned();
-        let expected = "$.".to_owned();
         let name = SecretString::new(Box::new(input));
         let result = hash_file_name(&name);
-        assert_eq!(result, expected);
+        assert_eq!(result, dot_entry_storage_name());
 
         let input = "..".to_owned();
-        let expected = "$..".to_owned();
         let name = SecretString::new(Box::new(input));
         let result = hash_file_name(&name);
-        assert_eq!(result, expected);
+        assert_eq!(result, dot_dot_entry_storage_name());
     }
 
     #[test]

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -274,6 +274,34 @@ pub fn hash_file_name(name: &SecretString) -> String {
     }
 }
 
+/// Returns every on-disk hash name that can represent `name`, preferring the
+/// native spelling. Dot entries have a second, cross-platform spelling.
+#[must_use]
+pub(crate) fn hash_file_name_candidates(name: &SecretString) -> Vec<String> {
+    match name.expose_secret().as_str() {
+        "$." | "." => {
+            let alternate = if dot_entry_storage_name() == "$dot" {
+                "$."
+            } else {
+                "$dot"
+            };
+            vec![dot_entry_storage_name().to_owned(), alternate.to_owned()]
+        }
+        "$.." | ".." => {
+            let alternate = if dot_dot_entry_storage_name() == "$dotdot" {
+                "$.."
+            } else {
+                "$dotdot"
+            };
+            vec![
+                dot_dot_entry_storage_name().to_owned(),
+                alternate.to_owned(),
+            ]
+        }
+        _ => vec![hex::encode(hash_secret_string(name))],
+    }
+}
+
 #[must_use]
 pub(crate) const fn dot_entry_storage_name() -> &'static str {
     if cfg!(target_os = "windows") {
@@ -601,6 +629,25 @@ mod tests {
         let name = SecretString::new(Box::new(input));
         let result = hash_file_name(&name);
         assert_eq!(result, dot_dot_entry_storage_name());
+    }
+
+    #[test]
+    fn test_hash_file_name_candidates_include_both_platform_spellings() {
+        let dot = SecretString::new(Box::new(".".to_owned()));
+        let dot_candidates = hash_file_name_candidates(&dot);
+        assert_eq!(dot_candidates[0], dot_entry_storage_name());
+        assert!(dot_candidates.iter().any(|candidate| candidate == "$."));
+        assert!(dot_candidates.iter().any(|candidate| candidate == "$dot"));
+
+        let dot_dot = SecretString::new(Box::new("..".to_owned()));
+        let dot_dot_candidates = hash_file_name_candidates(&dot_dot);
+        assert_eq!(dot_dot_candidates[0], dot_dot_entry_storage_name());
+        assert!(dot_dot_candidates
+            .iter()
+            .any(|candidate| candidate == "$.."));
+        assert!(dot_dot_candidates
+            .iter()
+            .any(|candidate| candidate == "$dotdot"));
     }
 
     #[test]

--- a/src/crypto/read.rs
+++ b/src/crypto/read.rs
@@ -71,8 +71,6 @@ macro_rules! decrypt_block {
     }};
 }
 
-pub(crate) use decrypt_block;
-
 #[allow(clippy::module_name_repetitions)]
 pub struct RingCryptoRead<R: Read> {
     input: Option<R>,

--- a/src/encryptedfs.rs
+++ b/src/encryptedfs.rs
@@ -50,8 +50,15 @@ pub(crate) const ROOT_INODE: u64 = 1;
 fn storage_entry_path(directory: &Path, name: &str) -> PathBuf {
     #[cfg(target_os = "windows")]
     if name.ends_with('.') {
-        if let Ok(verbatim_directory) = directory.canonicalize() {
-            return verbatim_directory.join(name);
+        match directory.canonicalize() {
+            Ok(verbatim_directory) => return verbatim_directory.join(name),
+            Err(error) => {
+                warn!(
+                    ?directory,
+                    %error,
+                    "failed to canonicalize backing directory for a trailing-dot entry"
+                );
+            }
         }
     }
 

--- a/src/encryptedfs.rs
+++ b/src/encryptedfs.rs
@@ -726,13 +726,12 @@ impl EncryptedFs {
                             // these operations are a bit slow, but are necessary to make sure the file is correctly created
                             // i.e. creating 100 files takes 0.965 sec with sync_all and 0.130 sec without
                             file.sync_all()?;
-                            File::open(
+                            fs_util::sync_directory(
                                 self_clone
                                     .contents_path(attr.ino)
                                     .parent()
                                     .expect("oops, we don't have a parent"),
-                            )?
-                            .sync_all()?;
+                            )?;
                             Ok::<(), FsError>(())
                         });
                     }
@@ -1136,9 +1135,9 @@ impl EncryptedFs {
         let entry = entry.unwrap();
         let name = entry.file_name().to_string_lossy().to_string();
         let name = {
-            if name == "$." {
+            if crypto::is_dot_entry_storage_name(&name) {
                 SecretString::new(Box::new(".".into()))
-            } else if name == "$.." {
+            } else if crypto::is_dot_dot_entry_storage_name(&name) {
                 SecretString::from_str("..").unwrap()
             } else {
                 // try from cache
@@ -1527,7 +1526,7 @@ impl EncryptedFs {
             let write_guard = lock.write().await;
             let file = writer.finish()?;
             file.sync_all()?;
-            File::open(self.contents_path(ctx.ino).parent().unwrap())?.sync_all()?;
+            fs_util::sync_directory(self.contents_path(ctx.ino).parent().unwrap())?;
             // write attr only here to avoid serializing it multiple times while writing
             // it will merge time fields with existing data because it might got change while we kept the handle
             let ino = ctx.ino;
@@ -1726,8 +1725,8 @@ impl EncryptedFs {
                 .get_or_insert_with(ctx.ino, || RwLock::new(false));
             let write_guard = lock.write().await;
             ctx.writer.as_mut().expect("writer is missing").flush()?;
-            File::open(self.contents_path(ctx.ino))?.sync_all()?;
-            File::open(self.contents_path(ctx.ino).parent().unwrap())?.sync_all()?;
+            fs_util::sync_file(&self.contents_path(ctx.ino))?;
+            fs_util::sync_directory(self.contents_path(ctx.ino).parent().unwrap())?;
             drop(write_guard);
             let ino = ctx.ino;
             drop(ctx);
@@ -1911,7 +1910,7 @@ impl EncryptedFs {
             }
             file.commit()?;
         }
-        File::open(file_path.parent().unwrap())?.sync_all()?;
+        fs_util::sync_directory(file_path.parent().unwrap())?;
 
         let now = SystemTime::now();
         let set_attr = SetFileAttr::default()
@@ -1962,7 +1961,7 @@ impl EncryptedFs {
                 let mut writer = ctx.writer.take().unwrap();
                 let file = writer.finish()?;
                 file.sync_all()?;
-                File::open(self.contents_path(ctx.ino).parent().unwrap())?.sync_all()?;
+                fs_util::sync_directory(self.contents_path(ctx.ino).parent().unwrap())?;
                 let handle = *handle;
                 let set_attr: SetFileAttr = ctx.attr.clone().into();
                 drop(ctx);
@@ -2210,7 +2209,7 @@ impl EncryptedFs {
                 let writer = ctx.writer.as_mut().unwrap();
                 let file = writer.finish()?;
                 file.sync_all()?;
-                File::open(self.contents_path(ctx.ino).parent().unwrap())?.sync_all()?;
+                fs_util::sync_directory(self.contents_path(ctx.ino).parent().unwrap())?;
                 let set_attr: Option<SetFileAttr> = if save_attr {
                     Some(ctx.attr.clone().into())
                 } else {
@@ -2514,7 +2513,7 @@ fn read_or_create_key(
         bincode::serialize_into(&mut file, &salt)?;
         file.flush()?;
         file.sync_all()?;
-        File::open(salt_path.parent().expect("oops, we don't have a parent"))?.sync_all()?;
+        fs_util::sync_directory(salt_path.parent().expect("oops, we don't have a parent"))?;
         salt
     };
     // derive key from password
@@ -2544,7 +2543,7 @@ fn read_or_create_key(
         bincode::serialize_into(&mut writer, &key)?;
         let file = writer.finish()?;
         file.sync_all()?;
-        File::open(key_path.parent().unwrap())?.sync_all()?;
+        fs_util::sync_directory(key_path.parent().unwrap())?;
         Ok(SecretBox::new(Box::new(key)))
     }
 }

--- a/src/encryptedfs.rs
+++ b/src/encryptedfs.rs
@@ -47,6 +47,17 @@ pub(crate) const HASH_DIR: &str = "hash";
 
 pub(crate) const ROOT_INODE: u64 = 1;
 
+fn storage_entry_path(directory: &Path, name: &str) -> PathBuf {
+    #[cfg(target_os = "windows")]
+    if name.ends_with('.') {
+        if let Ok(verbatim_directory) = directory.canonicalize() {
+            return verbatim_directory.join(name);
+        }
+    }
+
+    directory.join(name)
+}
+
 fn spawn_runtime() -> Runtime {
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -842,11 +853,14 @@ impl EncryptedFs {
         if !self.is_dir(parent) {
             return Err(FsError::InvalidInodeType);
         }
-        let hash = crypto::hash_file_name(name);
-        let hash_path = self.contents_path(parent).join(HASH_DIR).join(hash);
-        if !hash_path.is_file() {
+        let hash_dir = self.contents_path(parent).join(HASH_DIR);
+        let Some(hash_path) = crypto::hash_file_name_candidates(name)
+            .into_iter()
+            .map(|hash| storage_entry_path(&hash_dir, &hash))
+            .find(|path| path.is_file())
+        else {
             return Ok(None);
-        }
+        };
         let lock = self
             .serialize_dir_entries_hash_locks
             .get_or_insert_with(hash_path.to_str().unwrap().to_owned(), || {
@@ -1038,9 +1052,11 @@ impl EncryptedFs {
         if !self.is_dir(parent) {
             return Err(FsError::InvalidInodeType);
         }
-        let hash = crypto::hash_file_name(name);
-        let hash_path = self.contents_path(parent).join(HASH_DIR).join(hash);
-        Ok(hash_path.is_file())
+        let hash_dir = self.contents_path(parent).join(HASH_DIR);
+        Ok(crypto::hash_file_name_candidates(name)
+            .into_iter()
+            .map(|hash| storage_entry_path(&hash_dir, &hash))
+            .any(|path| path.is_file()))
     }
 
     #[allow(clippy::missing_errors_doc)]
@@ -1133,28 +1149,33 @@ impl EncryptedFs {
             return Err(e.into());
         }
         let entry = entry.unwrap();
-        let name = entry.file_name().to_string_lossy().to_string();
+        let storage_name = entry.file_name().to_string_lossy().to_string();
+        let entry_path = storage_entry_path(entry.path().parent().unwrap(), &storage_name);
         let name = {
-            if crypto::is_dot_entry_storage_name(&name) {
+            if crypto::is_dot_entry_storage_name(&storage_name) {
                 SecretString::new(Box::new(".".into()))
-            } else if crypto::is_dot_dot_entry_storage_name(&name) {
+            } else if crypto::is_dot_dot_entry_storage_name(&storage_name) {
                 SecretString::from_str("..").unwrap()
             } else {
                 // try from cache
                 let lock = self.get_dir_entries_name_cache().await?;
                 let mut cache = lock.lock().await;
-                if let Some(name_cached) = cache.get(&name).cloned() {
+                if let Some(name_cached) = cache.get(&storage_name).cloned() {
                     name_cached
                 } else {
                     drop(cache);
-                    if let Ok(decrypted_name) =
-                        crypto::decrypt_file_name(&name, self.cipher, &*self.key.get().await?)
-                            .map_err(|err| {
-                                error!(err = %err, "decrypting file name");
-                                err
-                            })
-                    {
-                        lock.lock().await.put(name.clone(), decrypted_name.clone());
+                    if let Ok(decrypted_name) = crypto::decrypt_file_name(
+                        &storage_name,
+                        self.cipher,
+                        &*self.key.get().await?,
+                    )
+                    .map_err(|err| {
+                        error!(err = %err, "decrypting file name");
+                        err
+                    }) {
+                        lock.lock()
+                            .await
+                            .put(storage_name.clone(), decrypted_name.clone());
                         decrypted_name
                     } else {
                         return Err(FsError::InvalidInput("invalid file name"));
@@ -1165,7 +1186,7 @@ impl EncryptedFs {
 
         self.validate_filename(&name)?;
 
-        let file_path = entry.path().to_str().unwrap().to_owned();
+        let file_path = entry_path.to_str().unwrap().to_owned();
         // try from cache
         let lock = self.dir_entries_meta_cache.get().await?;
         let mut cache = lock.lock().await;
@@ -1181,7 +1202,7 @@ impl EncryptedFs {
             .serialize_dir_entries_ls_locks
             .get_or_insert_with(file_path.clone(), || RwLock::new(false));
         let guard = lock.read().await;
-        let file = File::open(entry.path())?;
+        let file = File::open(entry_path)?;
         let res: bincode::Result<(u64, FileType)> = bincode::deserialize_from(crypto::create_read(
             file,
             self.cipher,
@@ -2342,8 +2363,23 @@ impl EncryptedFs {
         entry: &DirectoryEntry,
     ) -> FsResult<()> {
         let parent_path = self.contents_path(ino_contents_dir);
-        let encrypted_name =
-            crypto::encrypt_file_name(&entry.name, self.cipher, &*self.key.get().await?)?;
+        let hash_dir = parent_path.join(HASH_DIR);
+        let ls_dir = parent_path.join(LS_DIR);
+        let hash_candidates = crypto::hash_file_name_candidates(&entry.name);
+        let hash_name = hash_candidates
+            .iter()
+            .find(|name| storage_entry_path(&hash_dir, name).is_file())
+            .unwrap_or(&hash_candidates[0])
+            .clone();
+        let encrypted_name = if hash_candidates.len() > 1 {
+            hash_candidates
+                .iter()
+                .find(|name| storage_entry_path(&ls_dir, name).is_file())
+                .unwrap_or(&hash_candidates[0])
+                .clone()
+        } else {
+            crypto::encrypt_file_name(&entry.name, self.cipher, &*self.key.get().await?)?
+        };
         // add to LS directory
         let self_clone = self
             .self_weak
@@ -2353,14 +2389,12 @@ impl EncryptedFs {
             .unwrap()
             .upgrade()
             .unwrap();
-        let parent_path_clone = parent_path.clone();
+        let ls_dir_clone = ls_dir.clone();
         let encrypted_name_clone = encrypted_name.clone();
         let entry_clone = entry.clone();
         // spawn a task to do concurrently with adding to HASH directory
         let h = tokio::spawn(async move {
-            let file_path = parent_path_clone
-                .join(LS_DIR)
-                .join(encrypted_name_clone.clone());
+            let file_path = storage_entry_path(&ls_dir_clone, &encrypted_name_clone);
             let lock = self_clone
                 .serialize_dir_entries_ls_locks
                 .get_or_insert_with(file_path.to_str().unwrap().to_owned(), || {
@@ -2388,8 +2422,7 @@ impl EncryptedFs {
             .unwrap();
         let entry_hash = entry.clone();
         tokio::spawn(async move {
-            let name = crypto::hash_file_name(&entry_hash.name);
-            let file_path = parent_path.join(HASH_DIR).join(name);
+            let file_path = storage_entry_path(&hash_dir, &hash_name);
             let lock = self_clone
                 .serialize_dir_entries_hash_locks
                 .get_or_insert_with(file_path.to_str().unwrap().to_owned(), || {
@@ -2423,8 +2456,12 @@ impl EncryptedFs {
     async fn remove_directory_entry(&self, parent: u64, name: &SecretString) -> FsResult<()> {
         let parent_path = self.contents_path(parent);
         // remove from HASH
-        let name = crypto::hash_file_name(name);
-        let path = parent_path.join(HASH_DIR).join(name);
+        let hash_dir = parent_path.join(HASH_DIR);
+        let path = crypto::hash_file_name_candidates(name)
+            .into_iter()
+            .map(|hash| storage_entry_path(&hash_dir, &hash))
+            .find(|path| path.is_file())
+            .ok_or(FsError::NotFound("directory entry not found"))?;
         let lock = self
             .serialize_dir_entries_hash_locks
             .get_or_insert_with(path.to_str().unwrap().to_owned(), || RwLock::new(false));
@@ -2438,7 +2475,7 @@ impl EncryptedFs {
         fs::remove_file(path)?;
         drop(guard);
         // remove from LS
-        let path = parent_path.join(LS_DIR).join(name);
+        let path = storage_entry_path(&parent_path.join(LS_DIR), &name);
         let lock = self
             .serialize_dir_entries_ls_locks
             .get_or_insert_with(path.to_str().unwrap().to_owned(), || RwLock::new(false));

--- a/src/encryptedfs.rs
+++ b/src/encryptedfs.rs
@@ -590,7 +590,7 @@ pub struct EncryptedFs {
     // use std::sync::RwLock instead of tokio::sync::RwLock because we need to use it also in sync code in `DirectoryEntryIterator` and `DirectoryEntryPlusIterator`
     serialize_dir_entries_ls_locks: Arc<ArcHashMap<String, RwLock<bool>>>,
     serialize_dir_entries_hash_locks: Arc<ArcHashMap<String, RwLock<bool>>>,
-    directory_entry_mutation_lock: Mutex<()>,
+    directory_entry_mutation_locks: ArcHashMap<u64, Mutex<()>>,
     read_write_locks: ArcHashMap<u64, RwLock<bool>>,
     key: ExpireValue<SecretVec<u8>, FsError, KeyProvider>,
     self_weak: std::sync::Mutex<Option<Weak<Self>>>,
@@ -604,6 +604,10 @@ pub struct EncryptedFs {
     requested_read: Mutex<HashMap<u64, AtomicU64>>,
     #[cfg(test)]
     rename_fail_after_destination: AtomicBool,
+    #[cfg(test)]
+    directory_entry_fail_hash_write: AtomicBool,
+    #[cfg(test)]
+    directory_entry_fail_hash_remove: AtomicBool,
     read_only: bool,
 }
 
@@ -639,7 +643,7 @@ impl EncryptedFs {
             serialize_update_inode_locks: ArcHashMap::default(),
             serialize_dir_entries_ls_locks: Arc::new(ArcHashMap::default()),
             serialize_dir_entries_hash_locks: Arc::new(ArcHashMap::default()),
-            directory_entry_mutation_lock: Mutex::new(()),
+            directory_entry_mutation_locks: ArcHashMap::default(),
             key,
             self_weak: std::sync::Mutex::new(None),
             read_write_locks: ArcHashMap::default(),
@@ -660,6 +664,10 @@ impl EncryptedFs {
             requested_read: Mutex::default(),
             #[cfg(test)]
             rename_fail_after_destination: AtomicBool::new(false),
+            #[cfg(test)]
+            directory_entry_fail_hash_write: AtomicBool::new(false),
+            #[cfg(test)]
+            directory_entry_fail_hash_remove: AtomicBool::new(false),
             read_only,
         };
 
@@ -717,7 +725,10 @@ impl EncryptedFs {
         if self.read_only {
             return Err(FsError::ReadOnly);
         }
-        let _mutation_guard = self.directory_entry_mutation_lock.lock().await;
+        let mutation_lock = self
+            .directory_entry_mutation_locks
+            .get_or_insert_with(parent, || Mutex::new(()));
+        let _mutation_guard = mutation_lock.lock().await;
         if *name.expose_secret() == "." || *name.expose_secret() == ".." {
             return Err(FsError::InvalidInput("name cannot be '.' or '..'"));
         }
@@ -924,7 +935,10 @@ impl EncryptedFs {
         if self.read_only {
             return Err(FsError::ReadOnly);
         }
-        let _mutation_guard = self.directory_entry_mutation_lock.lock().await;
+        let mutation_lock = self
+            .directory_entry_mutation_locks
+            .get_or_insert_with(parent, || Mutex::new(()));
+        let _mutation_guard = mutation_lock.lock().await;
         if !self.is_dir(parent) {
             return Err(FsError::InvalidInodeType);
         }
@@ -1002,7 +1016,10 @@ impl EncryptedFs {
         if self.read_only {
             return Err(FsError::ReadOnly);
         }
-        let _mutation_guard = self.directory_entry_mutation_lock.lock().await;
+        let mutation_lock = self
+            .directory_entry_mutation_locks
+            .get_or_insert_with(parent, || Mutex::new(()));
+        let _mutation_guard = mutation_lock.lock().await;
         if !self.is_dir(parent) {
             return Err(FsError::InvalidInodeType);
         }
@@ -2058,7 +2075,23 @@ impl EncryptedFs {
         if self.read_only {
             return Err(FsError::ReadOnly);
         }
-        let _mutation_guard = self.directory_entry_mutation_lock.lock().await;
+        // Lock both namespace parents in inode order so unrelated directories
+        // remain concurrent and cross-directory renames cannot deadlock.
+        let first_parent = parent.min(new_parent);
+        let second_parent = parent.max(new_parent);
+        let first_mutation_lock = self
+            .directory_entry_mutation_locks
+            .get_or_insert_with(first_parent, || Mutex::new(()));
+        let _first_mutation_guard = first_mutation_lock.lock().await;
+        let second_mutation_lock = (second_parent != first_parent).then(|| {
+            self.directory_entry_mutation_locks
+                .get_or_insert_with(second_parent, || Mutex::new(()))
+        });
+        let _second_mutation_guard = if let Some(lock) = second_mutation_lock.as_ref() {
+            Some(lock.lock().await)
+        } else {
+            None
+        };
         if !self.exists(parent) {
             return Err(FsError::InodeNotFound);
         }
@@ -2607,6 +2640,17 @@ impl EncryptedFs {
     }
 
     async fn write_directory_entry_storage(&self, storage: &DirectoryEntryStorage) -> FsResult<()> {
+        let previous_hash = match fs::read(&storage.hash_path) {
+            Ok(contents) => Some(contents),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => None,
+            Err(error) => return Err(error.into()),
+        };
+        let previous_ls = match fs::read(&storage.ls_path) {
+            Ok(contents) => Some(contents),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => None,
+            Err(error) => return Err(error.into()),
+        };
+
         // add to LS directory
         let self_clone = self
             .self_weak
@@ -2619,7 +2663,7 @@ impl EncryptedFs {
         let ls_path = storage.ls_path.clone();
         let entry_clone = storage.entry.clone();
         // spawn a task to do concurrently with adding to HASH directory
-        let h = tokio::spawn(async move {
+        let ls_handle = tokio::spawn(async move {
             let lock = self_clone
                 .serialize_dir_entries_ls_locks
                 .get_or_insert_with(ls_path.to_str().unwrap().to_owned(), || RwLock::new(false));
@@ -2646,13 +2690,22 @@ impl EncryptedFs {
         let entry_hash = storage.entry.clone();
         let encrypted_name = storage.encrypted_name.clone();
         let hash_path = storage.hash_path.clone();
-        let hash_result = tokio::spawn(async move {
+        let hash_handle = tokio::spawn(async move {
             let lock = self_clone
                 .serialize_dir_entries_hash_locks
                 .get_or_insert_with(hash_path.to_str().unwrap().to_owned(), || {
                     RwLock::new(false)
                 });
             let _guard = lock.write().await;
+            #[cfg(test)]
+            if self_clone
+                .directory_entry_fail_hash_write
+                .swap(false, Ordering::SeqCst)
+            {
+                return Err(FsError::Other(
+                    "injected directory-entry hash write failure",
+                ));
+            }
             // write inode and file type
             // we save the encrypted name also because we need it to remove the entry on [`remove_directory_entry`]
             let entry = (entry_hash.ino, entry_hash.kind, encrypted_name);
@@ -2663,18 +2716,90 @@ impl EncryptedFs {
                 &*self_clone.key.get().await?,
             )?;
             Ok::<(), FsError>(())
-        })
-        .await?;
-        let ls_result = h.await?;
-        hash_result?;
-        ls_result?;
-        self.dir_entries_meta_cache
-            .get()
-            .await?
-            .lock()
-            .await
-            .pop(&storage.ls_path.to_string_lossy().to_string());
+        });
+
+        // Always await both halves. If either fails, restore the exact previous
+        // bytes (or remove a newly-created half) so lookups and listings cannot
+        // disagree about whether the entry exists.
+        let hash_result = hash_handle.await.map_err(FsError::from).and_then(|r| r);
+        let ls_result = ls_handle.await.map_err(FsError::from).and_then(|r| r);
+        let write_error = match (hash_result, ls_result) {
+            (Err(error), _) | (Ok(()), Err(error)) => Some(error),
+            (Ok(()), Ok(())) => None,
+        };
+        if let Some(error) = write_error {
+            if let Err(rollback_error) = self
+                .restore_directory_entry_file(&storage.hash_path, previous_hash.as_deref(), true)
+                .await
+            {
+                error!(
+                    err = %rollback_error,
+                    "failed to restore directory-entry hash after write failure"
+                );
+            }
+            if let Err(rollback_error) = self
+                .restore_directory_entry_file(&storage.ls_path, previous_ls.as_deref(), false)
+                .await
+            {
+                error!(
+                    err = %rollback_error,
+                    "failed to restore directory-entry listing after write failure"
+                );
+            }
+            return Err(error);
+        }
+
+        self.invalidate_directory_entry_meta_cache(&storage.ls_path)
+            .await;
         Ok(())
+    }
+
+    async fn restore_directory_entry_file(
+        &self,
+        path: &Path,
+        previous_contents: Option<&[u8]>,
+        is_hash_entry: bool,
+    ) -> FsResult<()> {
+        let locks = if is_hash_entry {
+            &self.serialize_dir_entries_hash_locks
+        } else {
+            &self.serialize_dir_entries_ls_locks
+        };
+        let lock =
+            locks.get_or_insert_with(path.to_str().unwrap().to_owned(), || RwLock::new(false));
+        let _guard = lock.write().await;
+        if let Some(previous_contents) = previous_contents {
+            let parent = path
+                .parent()
+                .ok_or(FsError::Other("directory entry has no parent"))?;
+            let mut file = fs_util::open_atomic_write(path)?;
+            file.write_all(previous_contents)?;
+            file.commit()?;
+            fs_util::sync_directory(parent)?;
+        } else {
+            match fs::remove_file(path) {
+                Ok(()) => {}
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+                Err(error) => return Err(error.into()),
+            }
+        }
+        drop(_guard);
+        if !is_hash_entry {
+            self.invalidate_directory_entry_meta_cache(path).await;
+        }
+        Ok(())
+    }
+
+    async fn invalidate_directory_entry_meta_cache(&self, path: &Path) {
+        match self.dir_entries_meta_cache.get().await {
+            Ok(cache) => {
+                cache.lock().await.pop(&path.to_string_lossy().to_string());
+            }
+            Err(error) => warn!(
+                err = %error,
+                "directory entry changed but its metadata cache could not be invalidated"
+            ),
+        }
     }
 
     async fn find_directory_entry_storage(
@@ -2721,6 +2846,15 @@ impl EncryptedFs {
             .serialize_dir_entries_hash_locks
             .get_or_insert_with(path.to_str().unwrap().to_owned(), || RwLock::new(false));
         let _guard = lock.write().await;
+        #[cfg(test)]
+        if self
+            .directory_entry_fail_hash_remove
+            .swap(false, Ordering::SeqCst)
+        {
+            return Err(FsError::Other(
+                "injected directory-entry hash removal failure",
+            ));
+        }
         match fs::remove_file(path) {
             Ok(()) => Ok(()),
             Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
@@ -2738,12 +2872,7 @@ impl EncryptedFs {
             Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
             Err(error) => Err(error.into()),
         };
-        self.dir_entries_meta_cache
-            .get()
-            .await?
-            .lock()
-            .await
-            .pop(&path.to_string_lossy().to_string());
+        self.invalidate_directory_entry_meta_cache(path).await;
         result
     }
 
@@ -2760,10 +2889,20 @@ impl EncryptedFs {
             .find_directory_entry_storage(parent, name)
             .await?
             .ok_or(FsError::NotFound("directory entry not found"))?;
-        self.remove_directory_entry_hash_file(&storage.hash_path)
-            .await?;
         self.remove_directory_entry_ls_file(&storage.ls_path)
             .await?;
+        if let Err(error) = self
+            .remove_directory_entry_hash_file(&storage.hash_path)
+            .await
+        {
+            if let Err(rollback_error) = self.write_directory_entry_storage(&storage).await {
+                error!(
+                    err = %rollback_error,
+                    "failed to restore directory entry after removal failure"
+                );
+            }
+            return Err(error);
+        }
         Ok(())
     }
 

--- a/src/encryptedfs.rs
+++ b/src/encryptedfs.rs
@@ -13,6 +13,8 @@ use std::io::{Read, Seek, SeekFrom, Write};
 use std::num::{NonZeroUsize, ParseIntError};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+#[cfg(test)]
+use std::sync::atomic::AtomicBool;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, LazyLock, Weak};
 use std::time::{Duration, SystemTime};
@@ -429,6 +431,14 @@ pub struct DirectoryEntry {
     pub kind: FileType,
 }
 
+#[derive(Debug, Clone)]
+struct DirectoryEntryStorage {
+    entry: DirectoryEntry,
+    hash_path: PathBuf,
+    ls_path: PathBuf,
+    encrypted_name: String,
+}
+
 impl PartialEq for DirectoryEntry {
     fn eq(&self, other: &Self) -> bool {
         self.ino == other.ino
@@ -580,6 +590,7 @@ pub struct EncryptedFs {
     // use std::sync::RwLock instead of tokio::sync::RwLock because we need to use it also in sync code in `DirectoryEntryIterator` and `DirectoryEntryPlusIterator`
     serialize_dir_entries_ls_locks: Arc<ArcHashMap<String, RwLock<bool>>>,
     serialize_dir_entries_hash_locks: Arc<ArcHashMap<String, RwLock<bool>>>,
+    directory_entry_mutation_lock: Mutex<()>,
     read_write_locks: ArcHashMap<u64, RwLock<bool>>,
     key: ExpireValue<SecretVec<u8>, FsError, KeyProvider>,
     self_weak: std::sync::Mutex<Option<Weak<Self>>>,
@@ -591,6 +602,8 @@ pub struct EncryptedFs {
     sizes_write: Mutex<HashMap<u64, AtomicU64>>,
     sizes_read: Mutex<HashMap<u64, AtomicU64>>,
     requested_read: Mutex<HashMap<u64, AtomicU64>>,
+    #[cfg(test)]
+    rename_fail_after_destination: AtomicBool,
     read_only: bool,
 }
 
@@ -626,6 +639,7 @@ impl EncryptedFs {
             serialize_update_inode_locks: ArcHashMap::default(),
             serialize_dir_entries_ls_locks: Arc::new(ArcHashMap::default()),
             serialize_dir_entries_hash_locks: Arc::new(ArcHashMap::default()),
+            directory_entry_mutation_lock: Mutex::new(()),
             key,
             self_weak: std::sync::Mutex::new(None),
             read_write_locks: ArcHashMap::default(),
@@ -644,6 +658,8 @@ impl EncryptedFs {
             sizes_write: Mutex::default(),
             sizes_read: Mutex::default(),
             requested_read: Mutex::default(),
+            #[cfg(test)]
+            rename_fail_after_destination: AtomicBool::new(false),
             read_only,
         };
 
@@ -701,6 +717,7 @@ impl EncryptedFs {
         if self.read_only {
             return Err(FsError::ReadOnly);
         }
+        let _mutation_guard = self.directory_entry_mutation_lock.lock().await;
         if *name.expose_secret() == "." || *name.expose_secret() == ".." {
             return Err(FsError::InvalidInput("name cannot be '.' or '..'"));
         }
@@ -907,6 +924,7 @@ impl EncryptedFs {
         if self.read_only {
             return Err(FsError::ReadOnly);
         }
+        let _mutation_guard = self.directory_entry_mutation_lock.lock().await;
         if !self.is_dir(parent) {
             return Err(FsError::InvalidInodeType);
         }
@@ -984,6 +1002,7 @@ impl EncryptedFs {
         if self.read_only {
             return Err(FsError::ReadOnly);
         }
+        let _mutation_guard = self.directory_entry_mutation_lock.lock().await;
         if !self.is_dir(parent) {
             return Err(FsError::InvalidInodeType);
         }
@@ -2023,9 +2042,23 @@ impl EncryptedFs {
         new_parent: u64,
         new_name: &SecretString,
     ) -> FsResult<()> {
+        self.rename_with_options(parent, name, new_parent, new_name, true)
+            .await
+    }
+
+    #[allow(clippy::missing_panics_doc)]
+    pub async fn rename_with_options(
+        &self,
+        parent: u64,
+        name: &SecretString,
+        new_parent: u64,
+        new_name: &SecretString,
+        replace_if_exists: bool,
+    ) -> FsResult<()> {
         if self.read_only {
             return Err(FsError::ReadOnly);
         }
+        let _mutation_guard = self.directory_entry_mutation_lock.lock().await;
         if !self.exists(parent) {
             return Err(FsError::InodeNotFound);
         }
@@ -2048,63 +2081,230 @@ impl EncryptedFs {
             return Ok(());
         }
 
-        // Only overwrite an existing directory if it's empty
-        if let Ok(Some(new_attr)) = self.find_by_name(new_parent, new_name).await {
-            if new_attr.kind == FileType::Directory && self.len(new_attr.ino)? > 0 {
+        let source_storage = self
+            .find_directory_entry_storage(parent, name)
+            .await?
+            .ok_or(FsError::NotFound("name not found"))?;
+        let attr = self
+            .get_inode_from_cache_or_storage(source_storage.entry.ino)
+            .await?;
+        let replaced_storage = self
+            .find_directory_entry_storage(new_parent, new_name)
+            .await?;
+        if let Some(replaced_storage) = replaced_storage.as_ref() {
+            if !replace_if_exists {
+                return Err(FsError::AlreadyExists);
+            }
+            if replaced_storage.entry.kind == FileType::Directory
+                && self.len(replaced_storage.entry.ino)? > 0
+            {
                 return Err(FsError::NotEmpty);
             }
         }
 
-        let attr = self
-            .find_by_name(parent, name)
-            .await?
-            .ok_or(FsError::NotFound("name not found"))?;
-        // remove from parent contents
-        self.remove_directory_entry(parent, name).await?;
-        // remove from new_parent contents, if exists
-        if self.exists_by_name(new_parent, new_name)? {
-            self.remove_directory_entry(new_parent, new_name).await?;
-        }
-        // add to new parent contents
-        self.insert_directory_entry(
-            new_parent,
-            &DirectoryEntry {
-                ino: attr.ino,
-                name: new_name.clone(),
-                kind: attr.kind,
-            },
-        )
-        .await?;
-
-        if attr.kind == FileType::Directory {
-            // add the parent link to the new directory
-            self.insert_directory_entry(
-                attr.ino,
-                &DirectoryEntry {
-                    ino: new_parent,
-                    name: SecretBox::new(Box::new("$..".to_owned())),
-                    kind: FileType::Directory,
-                },
-            )
+        let destination_entry = DirectoryEntry {
+            ino: attr.ino,
+            name: new_name.clone(),
+            kind: attr.kind,
+        };
+        let destination_storage = self
+            .prepare_directory_entry_storage(new_parent, &destination_entry)
             .await?;
+        let parent_link_changed = attr.kind == FileType::Directory && parent != new_parent;
+        let old_parent_link = if parent_link_changed {
+            self.find_directory_entry_storage(attr.ino, &SecretBox::new(Box::new("$..".to_owned())))
+                .await?
+        } else {
+            None
+        };
+        let new_parent_link = if parent_link_changed {
+            Some(
+                self.prepare_directory_entry_storage(
+                    attr.ino,
+                    &DirectoryEntry {
+                        ino: new_parent,
+                        name: SecretBox::new(Box::new("$..".to_owned())),
+                        kind: FileType::Directory,
+                    },
+                )
+                .await?,
+            )
+        } else {
+            None
+        };
+
+        // Commit the destination before removing the source. If a later step
+        // fails, the original inode data is still intact and the entries below
+        // can be restored while the namespace mutation lock is held.
+        if let Err(error) = self
+            .write_directory_entry_storage(&destination_storage)
+            .await
+        {
+            self.restore_replaced_directory_entry(&destination_storage, replaced_storage.as_ref())
+                .await;
+            return Err(error);
+        }
+        #[cfg(test)]
+        if self
+            .rename_fail_after_destination
+            .swap(false, Ordering::SeqCst)
+        {
+            self.restore_replaced_directory_entry(&destination_storage, replaced_storage.as_ref())
+                .await;
+            return Err(FsError::Other("injected rename failure"));
+        }
+
+        if let Some(storage) = new_parent_link.as_ref() {
+            if let Err(error) = self.write_directory_entry_storage(storage).await {
+                self.restore_replaced_directory_entry(storage, old_parent_link.as_ref())
+                    .await;
+                self.restore_replaced_directory_entry(
+                    &destination_storage,
+                    replaced_storage.as_ref(),
+                )
+                .await;
+                return Err(error);
+            }
+        }
+
+        if let Err(error) = self.remove_directory_entry(parent, name).await {
+            if let Err(rollback_error) = self.write_directory_entry_storage(&source_storage).await {
+                error!(
+                    err = %rollback_error,
+                    "failed to restore source directory entry after rename failure"
+                );
+            }
+            if let Some(new_parent_link) = new_parent_link.as_ref() {
+                self.restore_replaced_directory_entry(new_parent_link, old_parent_link.as_ref())
+                    .await;
+            }
+            self.restore_replaced_directory_entry(&destination_storage, replaced_storage.as_ref())
+                .await;
+            return Err(error);
+        }
+
+        if let Some(replaced_storage) = replaced_storage.as_ref() {
+            if replaced_storage.ls_path != destination_storage.ls_path {
+                if let Err(error) = self
+                    .remove_directory_entry_ls_file(&replaced_storage.ls_path)
+                    .await
+                {
+                    warn!(
+                        err = %error,
+                        "renamed successfully but could not remove replaced directory listing"
+                    );
+                }
+            }
+        }
+
+        // The new namespace is now committed. Deleting replaced inode storage
+        // is intentionally deferred until this point so a failed rename never
+        // destroys the original destination.
+        if let Some(replaced_storage) =
+            replaced_storage.filter(|storage| storage.entry.ino != attr.ino)
+        {
+            if let Err(error) = self
+                .remove_replaced_inode_storage(&replaced_storage.entry)
+                .await
+            {
+                warn!(
+                    ino = replaced_storage.entry.ino,
+                    err = %error,
+                    "renamed successfully but could not remove replaced inode storage"
+                );
+            }
         }
 
         let now = SystemTime::now();
-        let set_attr = SetFileAttr::default()
+        let parent_times = SetFileAttr::default()
             .with_mtime(now)
             .with_ctime(now)
             .with_atime(now);
-        self.set_attr(parent, set_attr).await?;
+        if let Err(error) = self.set_attr(parent, parent_times).await {
+            warn!(
+                ino = parent,
+                err = %error,
+                "renamed successfully but could not update source parent timestamps"
+            );
+        }
+        if new_parent != parent {
+            if let Err(error) = self.set_attr(new_parent, parent_times).await {
+                warn!(
+                    ino = new_parent,
+                    err = %error,
+                    "renamed successfully but could not update destination parent timestamps"
+                );
+            }
+        }
+        if let Err(error) = self
+            .set_attr(
+                attr.ino,
+                SetFileAttr::default().with_ctime(now).with_atime(now),
+            )
+            .await
+        {
+            warn!(
+                ino = attr.ino,
+                err = %error,
+                "renamed successfully but could not update inode timestamps"
+            );
+        }
 
-        let set_attr = SetFileAttr::default()
-            .with_mtime(now)
-            .with_ctime(now)
-            .with_atime(now);
-        self.set_attr(new_parent, set_attr).await?;
+        Ok(())
+    }
 
-        let set_attr = SetFileAttr::default().with_ctime(now).with_atime(now);
-        self.set_attr(attr.ino, set_attr).await?;
+    async fn restore_replaced_directory_entry(
+        &self,
+        new_storage: &DirectoryEntryStorage,
+        replaced_storage: Option<&DirectoryEntryStorage>,
+    ) {
+        let result = if let Some(replaced_storage) = replaced_storage {
+            self.write_directory_entry_storage(replaced_storage).await
+        } else {
+            self.remove_directory_entry_hash_file(&new_storage.hash_path)
+                .await
+        };
+        if let Err(error) = result {
+            error!(
+                err = %error,
+                "failed to restore replaced directory entry after rename failure"
+            );
+        }
+        let remove_new_listing = match replaced_storage {
+            Some(storage) => storage.ls_path != new_storage.ls_path,
+            None => true,
+        };
+        if remove_new_listing {
+            if let Err(error) = self
+                .remove_directory_entry_ls_file(&new_storage.ls_path)
+                .await
+            {
+                error!(
+                    err = %error,
+                    "failed to remove new directory listing after rename failure"
+                );
+            }
+        }
+    }
 
+    async fn remove_replaced_inode_storage(&self, entry: &DirectoryEntry) -> FsResult<()> {
+        {
+            let lock = self
+                .serialize_inode_locks
+                .get_or_insert_with(entry.ino, || RwLock::new(false));
+            let _guard = lock.write();
+            fs::remove_file(self.ino_file(entry.ino))?;
+        }
+        match entry.kind {
+            FileType::Directory => fs::remove_dir_all(self.contents_path(entry.ino))?,
+            FileType::RegularFile => fs::remove_file(self.contents_path(entry.ino))?,
+        }
+        self.attr_cache
+            .get()
+            .await?
+            .write()
+            .await
+            .demote(&entry.ino);
         Ok(())
     }
 
@@ -2369,6 +2569,17 @@ impl EncryptedFs {
         ino_contents_dir: u64,
         entry: &DirectoryEntry,
     ) -> FsResult<()> {
+        let storage = self
+            .prepare_directory_entry_storage(ino_contents_dir, entry)
+            .await?;
+        self.write_directory_entry_storage(&storage).await
+    }
+
+    async fn prepare_directory_entry_storage(
+        &self,
+        ino_contents_dir: u64,
+        entry: &DirectoryEntry,
+    ) -> FsResult<DirectoryEntryStorage> {
         let parent_path = self.contents_path(ino_contents_dir);
         let hash_dir = parent_path.join(HASH_DIR);
         let ls_dir = parent_path.join(LS_DIR);
@@ -2387,6 +2598,15 @@ impl EncryptedFs {
         } else {
             crypto::encrypt_file_name(&entry.name, self.cipher, &*self.key.get().await?)?
         };
+        Ok(DirectoryEntryStorage {
+            entry: entry.clone(),
+            hash_path: storage_entry_path(&hash_dir, &hash_name),
+            ls_path: storage_entry_path(&ls_dir, &encrypted_name),
+            encrypted_name,
+        })
+    }
+
+    async fn write_directory_entry_storage(&self, storage: &DirectoryEntryStorage) -> FsResult<()> {
         // add to LS directory
         let self_clone = self
             .self_weak
@@ -2396,22 +2616,18 @@ impl EncryptedFs {
             .unwrap()
             .upgrade()
             .unwrap();
-        let ls_dir_clone = ls_dir.clone();
-        let encrypted_name_clone = encrypted_name.clone();
-        let entry_clone = entry.clone();
+        let ls_path = storage.ls_path.clone();
+        let entry_clone = storage.entry.clone();
         // spawn a task to do concurrently with adding to HASH directory
         let h = tokio::spawn(async move {
-            let file_path = storage_entry_path(&ls_dir_clone, &encrypted_name_clone);
             let lock = self_clone
                 .serialize_dir_entries_ls_locks
-                .get_or_insert_with(file_path.to_str().unwrap().to_owned(), || {
-                    RwLock::new(false)
-                });
+                .get_or_insert_with(ls_path.to_str().unwrap().to_owned(), || RwLock::new(false));
             let _guard = lock.write().await;
             // write inode and file type
             let entry = (entry_clone.ino, entry_clone.kind);
             crypto::atomic_serialize_encrypt_into(
-                &file_path,
+                &ls_path,
                 &entry,
                 self_clone.cipher,
                 &*self_clone.key.get().await?,
@@ -2427,12 +2643,13 @@ impl EncryptedFs {
             .unwrap()
             .upgrade()
             .unwrap();
-        let entry_hash = entry.clone();
-        tokio::spawn(async move {
-            let file_path = storage_entry_path(&hash_dir, &hash_name);
+        let entry_hash = storage.entry.clone();
+        let encrypted_name = storage.encrypted_name.clone();
+        let hash_path = storage.hash_path.clone();
+        let hash_result = tokio::spawn(async move {
             let lock = self_clone
                 .serialize_dir_entries_hash_locks
-                .get_or_insert_with(file_path.to_str().unwrap().to_owned(), || {
+                .get_or_insert_with(hash_path.to_str().unwrap().to_owned(), || {
                     RwLock::new(false)
                 });
             let _guard = lock.write().await;
@@ -2440,16 +2657,94 @@ impl EncryptedFs {
             // we save the encrypted name also because we need it to remove the entry on [`remove_directory_entry`]
             let entry = (entry_hash.ino, entry_hash.kind, encrypted_name);
             crypto::atomic_serialize_encrypt_into(
-                &file_path,
+                &hash_path,
                 &entry,
                 self_clone.cipher,
                 &*self_clone.key.get().await?,
             )?;
             Ok::<(), FsError>(())
         })
-        .await??;
-        h.await??;
+        .await?;
+        let ls_result = h.await?;
+        hash_result?;
+        ls_result?;
+        self.dir_entries_meta_cache
+            .get()
+            .await?
+            .lock()
+            .await
+            .pop(&storage.ls_path.to_string_lossy().to_string());
         Ok(())
+    }
+
+    async fn find_directory_entry_storage(
+        &self,
+        parent: u64,
+        name: &SecretString,
+    ) -> FsResult<Option<DirectoryEntryStorage>> {
+        let parent_path = self.contents_path(parent);
+        let hash_dir = parent_path.join(HASH_DIR);
+        let Some(hash_path) = crypto::hash_file_name_candidates(name)
+            .into_iter()
+            .map(|hash| storage_entry_path(&hash_dir, &hash))
+            .find(|path| path.is_file())
+        else {
+            return Ok(None);
+        };
+        let lock = self
+            .serialize_dir_entries_hash_locks
+            .get_or_insert_with(hash_path.to_str().unwrap().to_owned(), || {
+                RwLock::new(false)
+            });
+        let guard = lock.read().await;
+        let (ino, kind, encrypted_name): (u64, FileType, String) =
+            bincode::deserialize_from(crypto::create_read(
+                File::open(&hash_path)?,
+                self.cipher,
+                &*self.key.get().await?,
+            ))?;
+        drop(guard);
+        Ok(Some(DirectoryEntryStorage {
+            entry: DirectoryEntry {
+                ino,
+                name: name.clone(),
+                kind,
+            },
+            hash_path,
+            ls_path: storage_entry_path(&parent_path.join(LS_DIR), &encrypted_name),
+            encrypted_name,
+        }))
+    }
+
+    async fn remove_directory_entry_hash_file(&self, path: &Path) -> FsResult<()> {
+        let lock = self
+            .serialize_dir_entries_hash_locks
+            .get_or_insert_with(path.to_str().unwrap().to_owned(), || RwLock::new(false));
+        let _guard = lock.write().await;
+        match fs::remove_file(path) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    async fn remove_directory_entry_ls_file(&self, path: &Path) -> FsResult<()> {
+        let lock = self
+            .serialize_dir_entries_ls_locks
+            .get_or_insert_with(path.to_str().unwrap().to_owned(), || RwLock::new(false));
+        let _guard = lock.write().await;
+        let result = match fs::remove_file(path) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error.into()),
+        };
+        self.dir_entries_meta_cache
+            .get()
+            .await?
+            .lock()
+            .await
+            .pop(&path.to_string_lossy().to_string());
+        result
     }
 
     fn ino_file(&self, ino: u64) -> PathBuf {
@@ -2461,33 +2756,14 @@ impl EncryptedFs {
     }
 
     async fn remove_directory_entry(&self, parent: u64, name: &SecretString) -> FsResult<()> {
-        let parent_path = self.contents_path(parent);
-        // remove from HASH
-        let hash_dir = parent_path.join(HASH_DIR);
-        let path = crypto::hash_file_name_candidates(name)
-            .into_iter()
-            .map(|hash| storage_entry_path(&hash_dir, &hash))
-            .find(|path| path.is_file())
+        let storage = self
+            .find_directory_entry_storage(parent, name)
+            .await?
             .ok_or(FsError::NotFound("directory entry not found"))?;
-        let lock = self
-            .serialize_dir_entries_hash_locks
-            .get_or_insert_with(path.to_str().unwrap().to_owned(), || RwLock::new(false));
-        let guard = lock.write().await;
-        let (_, _, name): (u64, FileType, String) =
-            bincode::deserialize_from(crypto::create_read(
-                File::open(path.clone())?,
-                self.cipher,
-                &*self.key.get().await?,
-            ))?;
-        fs::remove_file(path)?;
-        drop(guard);
-        // remove from LS
-        let path = storage_entry_path(&parent_path.join(LS_DIR), &name);
-        let lock = self
-            .serialize_dir_entries_ls_locks
-            .get_or_insert_with(path.to_str().unwrap().to_owned(), || RwLock::new(false));
-        let _guard = lock.write().await;
-        fs::remove_file(path)?;
+        self.remove_directory_entry_hash_file(&storage.hash_path)
+            .await?;
+        self.remove_directory_entry_ls_file(&storage.ls_path)
+            .await?;
         Ok(())
     }
 

--- a/src/encryptedfs/test.rs
+++ b/src/encryptedfs/test.rs
@@ -6,6 +6,7 @@ use shush_rs::{ExposeSecret, SecretString};
 use tracing_test::traced_test;
 
 use crate::crypto::Cipher;
+use crate::encryptedfs::storage_entry_path;
 use crate::encryptedfs::write_all_bytes_to_fs;
 use crate::encryptedfs::INODES_DIR;
 use crate::encryptedfs::KEY_ENC_FILENAME;
@@ -14,7 +15,7 @@ use crate::encryptedfs::SECURITY_DIR;
 use crate::encryptedfs::{CopyFileRangeReq, HASH_DIR};
 use crate::encryptedfs::{
     DirectoryEntry, DirectoryEntryPlus, EncryptedFs, FileType, FsError, FsResult, SetFileAttr,
-    CONTENTS_DIR, ROOT_INODE,
+    CONTENTS_DIR, LS_DIR, ROOT_INODE,
 };
 use crate::test_common::run_test;
 use crate::test_common::TestSetup;
@@ -964,6 +965,80 @@ async fn test_find_by_name() {
                     .await
                     .unwrap()
             );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_find_dot_entry_with_non_native_hash_spelling() {
+    run_test(
+        TestSetup {
+            key: "test_find_dot_entry_with_non_native_hash_spelling",
+            read_only: false,
+        },
+        async {
+            let fs = get_fs().await;
+            let dot = SecretString::from_str(".").unwrap();
+            let hash_dir = fs.contents_path(ROOT_INODE).join(HASH_DIR);
+            let ls_dir = fs.contents_path(ROOT_INODE).join(LS_DIR);
+            let candidates = crypto::hash_file_name_candidates(&dot);
+            let native_hash_path = storage_entry_path(&hash_dir, &candidates[0]);
+            let non_native_hash_path = storage_entry_path(&hash_dir, &candidates[1]);
+            let native_ls_path = storage_entry_path(&ls_dir, &candidates[0]);
+            let non_native_ls_path = storage_entry_path(&ls_dir, &candidates[1]);
+
+            std::fs::rename(&native_hash_path, &non_native_hash_path).unwrap();
+            std::fs::rename(&native_ls_path, &non_native_ls_path).unwrap();
+
+            assert!(fs.exists_by_name(ROOT_INODE, &dot).unwrap());
+            assert_eq!(
+                ROOT_INODE,
+                fs.find_by_name(ROOT_INODE, &dot)
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .ino
+            );
+            assert_eq!(
+                1,
+                fs.read_dir(ROOT_INODE)
+                    .await
+                    .unwrap()
+                    .filter(|entry| *entry.as_ref().unwrap().name.expose_secret() == ".")
+                    .count()
+            );
+
+            fs.insert_directory_entry(
+                ROOT_INODE,
+                &DirectoryEntry {
+                    ino: ROOT_INODE,
+                    name: dot.clone(),
+                    kind: FileType::Directory,
+                },
+            )
+            .await
+            .unwrap();
+            assert!(!native_hash_path.exists());
+            assert!(non_native_hash_path.exists());
+            assert!(!native_ls_path.exists());
+            assert!(non_native_ls_path.exists());
+
+            fs.remove_directory_entry(ROOT_INODE, &dot).await.unwrap();
+            assert!(!non_native_hash_path.exists());
+            assert!(!non_native_ls_path.exists());
+
+            fs.insert_directory_entry(
+                ROOT_INODE,
+                &DirectoryEntry {
+                    ino: ROOT_INODE,
+                    name: dot,
+                    kind: FileType::Directory,
+                },
+            )
+            .await
+            .unwrap();
         },
     )
     .await;

--- a/src/encryptedfs/test.rs
+++ b/src/encryptedfs/test.rs
@@ -2540,6 +2540,68 @@ async fn _test_sample() {
 
 #[tokio::test]
 #[traced_test]
+async fn test_directory_entry_pair_rolls_back_on_partial_failure() {
+    run_test(
+        TestSetup {
+            key: "test_directory_entry_pair_rolls_back_on_partial_failure",
+            read_only: false,
+        },
+        async {
+            let fs = get_fs().await;
+            let name = SecretString::from_str("transactional-entry").unwrap();
+            let entry = DirectoryEntry {
+                ino: ROOT_INODE,
+                name: name.clone(),
+                kind: FileType::Directory,
+            };
+
+            fs.directory_entry_fail_hash_write
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+            assert!(matches!(
+                fs.insert_directory_entry(ROOT_INODE, &entry).await,
+                Err(FsError::Other(
+                    "injected directory-entry hash write failure"
+                ))
+            ));
+            assert!(!fs.exists_by_name(ROOT_INODE, &name).unwrap());
+            assert_eq!(
+                fs.read_dir(ROOT_INODE)
+                    .await
+                    .unwrap()
+                    .map(Result::unwrap)
+                    .filter(|candidate| candidate.name.expose_secret() == name.expose_secret())
+                    .count(),
+                0
+            );
+
+            fs.insert_directory_entry(ROOT_INODE, &entry).await.unwrap();
+            fs.directory_entry_fail_hash_remove
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+            assert!(matches!(
+                fs.remove_directory_entry(ROOT_INODE, &name).await,
+                Err(FsError::Other(
+                    "injected directory-entry hash removal failure"
+                ))
+            ));
+            assert!(fs.exists_by_name(ROOT_INODE, &name).unwrap());
+            assert_eq!(
+                fs.read_dir(ROOT_INODE)
+                    .await
+                    .unwrap()
+                    .map(Result::unwrap)
+                    .filter(|candidate| candidate.name.expose_secret() == name.expose_secret())
+                    .count(),
+                1
+            );
+
+            fs.remove_directory_entry(ROOT_INODE, &name).await.unwrap();
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+#[traced_test]
 #[allow(clippy::too_many_lines)]
 async fn test_read_only_create() {
     run_test(

--- a/src/encryptedfs/test.rs
+++ b/src/encryptedfs/test.rs
@@ -1750,7 +1750,7 @@ async fn test_rename() {
                 )
                 .await
                 .unwrap();
-            let (_, _attr_2) = fs
+            let (_, attr_2) = fs
                 .create(
                     new_parent,
                     &file_2,
@@ -1760,6 +1760,27 @@ async fn test_rename() {
                 )
                 .await
                 .unwrap();
+            assert!(matches!(
+                fs.rename_with_options(ROOT_INODE, &file_1, new_parent, &file_2, false)
+                    .await,
+                Err(FsError::AlreadyExists)
+            ));
+            assert_eq!(
+                fs.find_by_name(ROOT_INODE, &file_1)
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .ino,
+                attr.ino
+            );
+            assert_eq!(
+                fs.find_by_name(new_parent, &file_2)
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .ino,
+                attr_2.ino
+            );
             fs.rename(ROOT_INODE, &file_1, new_parent, &file_2)
                 .await
                 .unwrap();
@@ -1767,6 +1788,8 @@ async fn test_rename() {
             assert!(fs.exists_by_name(new_parent, &file_2).unwrap());
             let new_attr = fs.find_by_name(new_parent, &file_2).await.unwrap().unwrap();
             assert!(fs.is_file(new_attr.ino));
+            assert!(!fs.exists(attr_2.ino));
+            assert!(!fs.is_file(attr_2.ino));
             assert_eq!(new_attr.ino, attr.ino);
             assert_eq!(new_attr.kind, attr.kind);
             assert_eq!(
@@ -1800,7 +1823,7 @@ async fn test_rename() {
                 )
                 .await
                 .unwrap();
-            let (_, _attr_2) = fs
+            let (_, attr_2) = fs
                 .create(
                     new_parent,
                     &dir_2,
@@ -1817,6 +1840,8 @@ async fn test_rename() {
             assert!(fs.exists_by_name(new_parent, &dir_2).unwrap());
             let new_attr = fs.find_by_name(new_parent, &dir_2).await.unwrap().unwrap();
             assert!(fs.is_dir(new_attr.ino));
+            assert!(!fs.exists(attr_2.ino));
+            assert!(!fs.is_dir(attr_2.ino));
             assert_eq!(new_attr.ino, attr.ino);
             assert_eq!(new_attr.kind, attr.kind);
             assert_eq!(
@@ -2344,6 +2369,114 @@ async fn test_rename() {
                     .await,
                 Err(FsError::InvalidInodeType)
             ));
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_rename_replacement_rolls_back_on_failure() {
+    run_test(
+        TestSetup {
+            key: "test_rename_replacement_rolls_back_on_failure",
+            read_only: false,
+        },
+        async {
+            let fs = get_fs().await;
+            let source = SecretString::from_str("source").unwrap();
+            let destination = SecretString::from_str("destination").unwrap();
+
+            let (source_handle, source_attr) = fs
+                .create(
+                    ROOT_INODE,
+                    &source,
+                    create_attr(FileType::RegularFile),
+                    false,
+                    true,
+                )
+                .await
+                .unwrap();
+            write_all_bytes_to_fs(&fs, source_attr.ino, 0, b"source data", source_handle)
+                .await
+                .unwrap();
+            fs.flush(source_handle).await.unwrap();
+            fs.release(source_handle).await.unwrap();
+
+            let (destination_handle, destination_attr) = fs
+                .create(
+                    ROOT_INODE,
+                    &destination,
+                    create_attr(FileType::RegularFile),
+                    false,
+                    true,
+                )
+                .await
+                .unwrap();
+            write_all_bytes_to_fs(
+                &fs,
+                destination_attr.ino,
+                0,
+                b"destination data",
+                destination_handle,
+            )
+            .await
+            .unwrap();
+            fs.flush(destination_handle).await.unwrap();
+            fs.release(destination_handle).await.unwrap();
+
+            fs.rename_fail_after_destination
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+            assert!(matches!(
+                fs.rename_with_options(ROOT_INODE, &source, ROOT_INODE, &destination, true)
+                    .await,
+                Err(FsError::Other("injected rename failure"))
+            ));
+
+            assert_eq!(
+                fs.find_by_name(ROOT_INODE, &source)
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .ino,
+                source_attr.ino
+            );
+            assert_eq!(
+                fs.find_by_name(ROOT_INODE, &destination)
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .ino,
+                destination_attr.ino
+            );
+            assert_eq!(
+                test_common::read_to_string(source_attr.ino, &fs).await,
+                "source data"
+            );
+            assert_eq!(
+                test_common::read_to_string(destination_attr.ino, &fs).await,
+                "destination data"
+            );
+            let entries: Vec<_> = fs
+                .read_dir(ROOT_INODE)
+                .await
+                .unwrap()
+                .map(Result::unwrap)
+                .collect();
+            assert_eq!(
+                entries
+                    .iter()
+                    .filter(|entry| entry.name.expose_secret() == source.expose_secret())
+                    .count(),
+                1
+            );
+            assert_eq!(
+                entries
+                    .iter()
+                    .filter(|entry| entry.name.expose_secret() == destination.expose_secret())
+                    .count(),
+                1
+            );
         },
     )
     .await;

--- a/src/fs_util.rs
+++ b/src/fs_util.rs
@@ -43,3 +43,33 @@ pub fn open_atomic_write(file: &Path) -> io::Result<AtomicWriteFile> {
     opt.preserve_mode(true).preserve_owner(true);
     opt.open(file)
 }
+
+/// Flush directory metadata when the platform exposes directories as regular
+/// file handles. Windows' standard `File::open` cannot open a directory, and
+/// file contents are already flushed by callers before this function is used.
+pub fn sync_directory(path: &Path) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        std::fs::File::open(path)?.sync_all()
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+        Ok(())
+    }
+}
+
+/// Flush an existing file using an access mode accepted by the platform.
+pub fn sync_file(path: &Path) -> io::Result<()> {
+    #[cfg(target_os = "windows")]
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(path)?;
+
+    #[cfg(not(target_os = "windows"))]
+    let file = std::fs::File::open(path)?;
+
+    file.sync_all()
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,12 +2,12 @@ use anyhow::Result;
 
 mod keyring;
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 mod run;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    #[cfg(target_os = "macos")]
     {
         eprintln!("he he, not yet ready for this platform, but soon my friend, soon :)");
         eprintln!("Bye!");
@@ -20,6 +20,6 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
     run::run().await
 }

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -3,10 +3,12 @@ use crate::encryptedfs::{FsResult, PasswordProvider};
 use async_trait::async_trait;
 use futures_util::FutureExt;
 use std::future::Future;
+use std::io;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
+#[cfg(target_os = "linux")]
+use std::process;
 use std::task::{Context, Poll};
-use std::{io, process};
 
 #[cfg(target_os = "linux")]
 mod linux;
@@ -15,11 +17,18 @@ use linux::MountHandleInnerImpl;
 #[cfg(target_os = "linux")]
 use linux::MountPointImpl;
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(target_os = "windows")]
+mod windows;
+#[cfg(target_os = "windows")]
+use windows::MountHandleInnerImpl;
+#[cfg(target_os = "windows")]
+use windows::MountPointImpl;
+
+#[cfg(not(any(target_os = "linux", target_os = "windows")))]
 mod dummy;
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "windows")))]
 use dummy::MountHandleInnerImpl;
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "windows")))]
 use dummy::MountPointImpl;
 
 #[async_trait]
@@ -97,6 +106,7 @@ pub fn create_mount_point(
     )
 }
 
+#[cfg(target_os = "linux")]
 pub fn umount(mountpoint: &str) -> io::Result<()> {
     // try normal umount
     if process::Command::new("umount")
@@ -129,4 +139,18 @@ pub fn umount(mountpoint: &str) -> io::Result<()> {
     } else {
         Err(io::Error::other(format!("cannot umount {mountpoint}")))
     }
+}
+
+#[cfg(target_os = "windows")]
+pub fn umount(_mountpoint: &str) -> io::Result<()> {
+    // WinFSP mount points are removed by `MountHandle::umount`. There is no
+    // separate process-wide unmount command to invoke here.
+    Ok(())
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "windows")))]
+pub fn umount(_mountpoint: &str) -> io::Result<()> {
+    Err(io::Error::other(
+        "unmount is not supported on this platform",
+    ))
 }

--- a/src/mount/windows.rs
+++ b/src/mount/windows.rs
@@ -9,6 +9,14 @@ use std::task::{Context, Poll};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::runtime::Runtime;
 use tracing::{error, info};
+use windows_sys::Win32::{
+    Foundation::{CloseHandle, LocalFree, HANDLE},
+    Security::{
+        Authorization::ConvertSidToStringSidW, GetTokenInformation, TokenUser, TOKEN_QUERY,
+        TOKEN_USER,
+    },
+    System::Threading::{GetCurrentProcess, OpenProcessToken},
+};
 use winfsp_wrs::{
     u16cstr, u16str, CleanupFlags, CreateFileInfo, CreateOptions, DirInfo, FileAccessRights,
     FileAttributes, FileInfo, FileSystem, FileSystemInterface, PSecurityDescriptor, Params,
@@ -30,10 +38,31 @@ use crate::mount::{MountHandleInner, MountPoint};
 const ALLOCATION_UNIT: u64 = 4096;
 const VOLUME_SIZE: u64 = 1024 * 1024 * 1024 * 1024;
 
+struct OwnedHandle(HANDLE);
+
+impl Drop for OwnedHandle {
+    fn drop(&mut self) {
+        unsafe {
+            CloseHandle(self.0);
+        }
+    }
+}
+
+struct LocalAllocation(*mut std::ffi::c_void);
+
+impl Drop for LocalAllocation {
+    fn drop(&mut self) {
+        unsafe {
+            LocalFree(self.0);
+        }
+    }
+}
+
 #[derive(Debug)]
 struct WindowsFileContext {
     ino: u64,
     handle: Mutex<Option<u64>>,
+    directory_entries: Mutex<Option<Vec<(String, FileInfo)>>>,
     is_dir: bool,
     read: bool,
     write: bool,
@@ -53,10 +82,7 @@ impl WindowsFs {
             .enable_all()
             .build()
             .map_err(FsError::from)?;
-        let security_descriptor = SecurityDescriptor::from_wstr(u16cstr!(
-            "O:BAG:BAD:P(A;;FA;;;SY)(A;;FA;;;BA)(A;;FA;;;WD)"
-        ))
-        .map_err(|_| FsError::Other("cannot create Windows security descriptor"))?;
+        let security_descriptor = default_security_descriptor()?;
         let volume_info = VolumeInfo::new(VOLUME_SIZE, VOLUME_SIZE, u16str!("rencfs"))
             .map_err(|_| FsError::Other("cannot create Windows volume info"))?;
 
@@ -123,6 +149,7 @@ impl WindowsFs {
             return Ok(Arc::new(WindowsFileContext {
                 ino: attr.ino,
                 handle: Mutex::new(None),
+                directory_entries: Mutex::new(None),
                 is_dir: true,
                 read: false,
                 write: false,
@@ -134,6 +161,7 @@ impl WindowsFs {
         Ok(Arc::new(WindowsFileContext {
             ino: attr.ino,
             handle: Mutex::new(Some(handle)),
+            directory_entries: Mutex::new(None),
             is_dir: false,
             read,
             write,
@@ -243,6 +271,7 @@ impl FileSystemInterface for WindowsFs {
         let context = Arc::new(WindowsFileContext {
             ino: attr.ino,
             handle: Mutex::new((handle != 0).then_some(handle)),
+            directory_entries: Mutex::new(None),
             is_dir,
             read,
             write,
@@ -502,18 +531,28 @@ impl FileSystemInterface for WindowsFs {
         if !file_context.is_dir {
             return Err(STATUS_NOT_A_DIRECTORY);
         }
-        let iter = self.block_on(self.fs.read_dir_plus(file_context.ino))?;
         let marker = marker.map(U16CStr::to_string_lossy);
-        let mut entries = Vec::new();
-        for entry in iter {
-            let entry = entry.map_err(fs_error_to_status)?;
-            entries.push((
-                entry.name.expose_secret().to_string(),
-                attr_to_file_info(entry.attr),
-            ));
+        let mut cached_entries = file_context
+            .directory_entries
+            .lock()
+            .map_err(|_| STATUS_INVALID_HANDLE)?;
+        if marker.is_none() || cached_entries.is_none() {
+            let iter = self.block_on(self.fs.read_dir_plus(file_context.ino))?;
+            let mut entries = Vec::new();
+            for entry in iter {
+                let entry = entry.map_err(fs_error_to_status)?;
+                entries.push((
+                    entry.name.expose_secret().to_string(),
+                    attr_to_file_info(entry.attr),
+                ));
+            }
+            entries.sort_by(|left, right| left.0.cmp(&right.0));
+            *cached_entries = Some(entries);
         }
-        entries.sort_by(|left, right| left.0.cmp(&right.0));
+        let entries = cached_entries.as_ref().unwrap().clone();
+        drop(cached_entries);
 
+        let mut exhausted = true;
         for (name, info) in entries {
             if marker
                 .as_deref()
@@ -525,10 +564,69 @@ impl FileSystemInterface for WindowsFs {
                 continue;
             }
             if !add_dir_info(DirInfo::from_str(info, &name)) {
+                exhausted = false;
                 break;
             }
         }
+        if exhausted {
+            file_context
+                .directory_entries
+                .lock()
+                .map_err(|_| STATUS_INVALID_HANDLE)?
+                .take();
+        }
         Ok(())
+    }
+}
+
+fn default_security_descriptor() -> FsResult<SecurityDescriptor> {
+    let user_sid = current_user_sid()?;
+    let descriptor =
+        format!("O:{user_sid}G:{user_sid}D:P(A;;FA;;;SY)(A;;FA;;;BA)(A;;FA;;;{user_sid})");
+    let descriptor = U16CString::from_str(&descriptor)
+        .map_err(|_| FsError::Other("invalid Windows security descriptor"))?;
+    SecurityDescriptor::from_wstr(&descriptor)
+        .map_err(|_| FsError::Other("cannot create Windows security descriptor"))
+}
+
+fn current_user_sid() -> FsResult<String> {
+    unsafe {
+        let mut token = 0;
+        if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) == 0 {
+            return Err(io::Error::last_os_error().into());
+        }
+        let _token = OwnedHandle(token);
+
+        let mut required = 0;
+        GetTokenInformation(token, TokenUser, std::ptr::null_mut(), 0, &mut required);
+        if required == 0 {
+            return Err(FsError::Other("cannot determine Windows token user size"));
+        }
+
+        let word_size = std::mem::size_of::<usize>() as u32;
+        let mut token_info = vec![0_usize; required.div_ceil(word_size) as usize];
+        if GetTokenInformation(
+            token,
+            TokenUser,
+            token_info.as_mut_ptr().cast(),
+            required,
+            &mut required,
+        ) == 0
+        {
+            return Err(io::Error::last_os_error().into());
+        }
+
+        let token_user = &*token_info.as_ptr().cast::<TOKEN_USER>();
+        let mut sid_string = std::ptr::null_mut();
+        if ConvertSidToStringSidW(token_user.User.Sid, &mut sid_string) == 0 {
+            return Err(io::Error::last_os_error().into());
+        }
+        let _sid_string = LocalAllocation(sid_string.cast());
+        let len = (0..)
+            .take_while(|offset| *sid_string.add(*offset) != 0)
+            .count();
+        String::from_utf16(std::slice::from_raw_parts(sid_string, len))
+            .map_err(|_| FsError::Other("Windows user SID is not valid UTF-16"))
     }
 }
 
@@ -740,8 +838,7 @@ mod tests {
     }
 
     fn test_security_descriptor() -> SecurityDescriptor {
-        SecurityDescriptor::from_wstr(u16cstr!("O:BAG:BAD:P(A;;FA;;;SY)(A;;FA;;;BA)(A;;FA;;;WD)"))
-            .unwrap()
+        default_security_descriptor().unwrap()
     }
 
     fn file_create_info() -> CreateFileInfo {
@@ -795,7 +892,6 @@ mod tests {
                 false,
             ))
             .unwrap();
-        drop(setup_runtime);
 
         let adapter = WindowsFs::new(encrypted_fs, false).unwrap();
         let original_name = U16CString::from_str(r"\hello.txt").unwrap();

--- a/src/mount/windows.rs
+++ b/src/mount/windows.rs
@@ -500,17 +500,13 @@ impl FileSystemInterface for WindowsFs {
         if parent == new_parent && name.expose_secret() == new_name.expose_secret() {
             return Ok(());
         }
-        if let Some(existing) = self.block_on(self.fs.find_by_name(new_parent, &new_name))? {
-            if !replace_if_exists {
-                return Err(STATUS_OBJECT_NAME_COLLISION);
-            }
-            if existing.kind == FileType::Directory {
-                self.block_on(self.fs.remove_dir(new_parent, &new_name))?;
-            } else {
-                self.block_on(self.fs.remove_file(new_parent, &new_name))?;
-            }
-        }
-        self.block_on(self.fs.rename(parent, &name, new_parent, &new_name))
+        self.block_on(self.fs.rename_with_options(
+            parent,
+            &name,
+            new_parent,
+            &new_name,
+            replace_if_exists,
+        ))
     }
 
     const GET_SECURITY_DEFINED: bool = true;
@@ -549,9 +545,7 @@ impl FileSystemInterface for WindowsFs {
             entries.sort_by(|left, right| left.0.cmp(&right.0));
             *cached_entries = Some(entries);
         }
-        let entries = cached_entries.as_ref().unwrap().clone();
-        drop(cached_entries);
-
+        let entries = cached_entries.as_ref().unwrap();
         let mut exhausted = true;
         for (name, info) in entries {
             if marker
@@ -560,20 +554,17 @@ impl FileSystemInterface for WindowsFs {
             {
                 continue;
             }
+            // DirInfo reserves one UTF-16 unit for the trailing NUL.
             if name.encode_utf16().count() >= 255 {
                 continue;
             }
-            if !add_dir_info(DirInfo::from_str(info, &name)) {
+            if !add_dir_info(DirInfo::from_str(*info, name)) {
                 exhausted = false;
                 break;
             }
         }
         if exhausted {
-            file_context
-                .directory_entries
-                .lock()
-                .map_err(|_| STATUS_INVALID_HANDLE)?
-                .take();
+            cached_entries.take();
         }
         Ok(())
     }
@@ -893,7 +884,7 @@ mod tests {
             ))
             .unwrap();
 
-        let adapter = WindowsFs::new(encrypted_fs, false).unwrap();
+        let adapter = WindowsFs::new(encrypted_fs.clone(), false).unwrap();
         let original_name = U16CString::from_str(r"\hello.txt").unwrap();
         let renamed_name = U16CString::from_str(r"\renamed.txt").unwrap();
         let replacement_name = U16CString::from_str(r"\replacement.txt").unwrap();
@@ -979,6 +970,7 @@ mod tests {
             )
             .unwrap();
         adapter.close(replacement_context);
+        let replaced_ino = adapter.resolve_path(&replacement_name).unwrap().ino;
         let (rename_context, _) = adapter
             .open(
                 &renamed_name,
@@ -986,6 +978,17 @@ mod tests {
                 FileAccessRights::FILE_GENERIC_READ | FileAccessRights::DELETE,
             )
             .unwrap();
+        assert_eq!(
+            adapter.rename(
+                rename_context.clone(),
+                &renamed_name,
+                &replacement_name,
+                false,
+            ),
+            Err(STATUS_OBJECT_NAME_COLLISION)
+        );
+        assert!(adapter.resolve_path(&renamed_name).is_ok());
+        assert_eq!(adapter.resolve_path(&replacement_name).unwrap().size, 0);
         adapter
             .rename(
                 rename_context.clone(),
@@ -1000,6 +1003,8 @@ mod tests {
             adapter.resolve_path(&replacement_name).unwrap().size,
             payload.len() as u64
         );
+        assert!(!encrypted_fs.exists(replaced_ino));
+        assert!(!encrypted_fs.is_file(replaced_ino));
 
         let (delete_context, _) = adapter
             .open(

--- a/src/mount/windows.rs
+++ b/src/mount/windows.rs
@@ -1,0 +1,926 @@
+use async_trait::async_trait;
+use shush_rs::{ExposeSecret, SecretString};
+use std::future::Future;
+use std::io;
+use std::path::PathBuf;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio::runtime::Runtime;
+use tracing::{error, info};
+use winfsp_wrs::{
+    u16cstr, u16str, CleanupFlags, CreateFileInfo, CreateOptions, DirInfo, FileAccessRights,
+    FileAttributes, FileInfo, FileSystem, FileSystemInterface, PSecurityDescriptor, Params,
+    SecurityDescriptor, U16CStr, U16CString, VolumeInfo, VolumeParams, WriteMode, NTSTATUS,
+    STATUS_ACCESS_DENIED, STATUS_DIRECTORY_NOT_EMPTY, STATUS_DISK_FULL, STATUS_END_OF_FILE,
+    STATUS_FILE_IS_A_DIRECTORY, STATUS_INVALID_HANDLE, STATUS_INVALID_PARAMETER,
+    STATUS_MEDIA_WRITE_PROTECTED, STATUS_NOT_A_DIRECTORY, STATUS_OBJECT_NAME_COLLISION,
+    STATUS_OBJECT_NAME_NOT_FOUND, STATUS_OBJECT_PATH_NOT_FOUND, STATUS_UNEXPECTED_IO_ERROR,
+};
+
+use crate::crypto::Cipher;
+use crate::encryptedfs::{
+    CreateFileAttr, EncryptedFs, FileAttr, FileType, FsError, FsResult, PasswordProvider,
+    SetFileAttr, ROOT_INODE,
+};
+use crate::mount;
+use crate::mount::{MountHandleInner, MountPoint};
+
+const ALLOCATION_UNIT: u64 = 4096;
+const VOLUME_SIZE: u64 = 1024 * 1024 * 1024 * 1024;
+
+#[derive(Debug)]
+struct WindowsFileContext {
+    ino: u64,
+    handle: Mutex<Option<u64>>,
+    is_dir: bool,
+    read: bool,
+    write: bool,
+}
+
+struct WindowsFs {
+    fs: Arc<EncryptedFs>,
+    runtime: Runtime,
+    security_descriptor: SecurityDescriptor,
+    volume_info: VolumeInfo,
+    read_only: bool,
+}
+
+impl WindowsFs {
+    fn new(fs: Arc<EncryptedFs>, read_only: bool) -> FsResult<Self> {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .map_err(FsError::from)?;
+        let security_descriptor = SecurityDescriptor::from_wstr(u16cstr!(
+            "O:BAG:BAD:P(A;;FA;;;SY)(A;;FA;;;BA)(A;;FA;;;WD)"
+        ))
+        .map_err(|_| FsError::Other("cannot create Windows security descriptor"))?;
+        let volume_info = VolumeInfo::new(VOLUME_SIZE, VOLUME_SIZE, u16str!("rencfs"))
+            .map_err(|_| FsError::Other("cannot create Windows volume info"))?;
+
+        Ok(Self {
+            fs,
+            runtime,
+            security_descriptor,
+            volume_info,
+            read_only,
+        })
+    }
+
+    fn block_on<T>(&self, future: impl Future<Output = FsResult<T>>) -> Result<T, NTSTATUS> {
+        self.runtime.block_on(future).map_err(fs_error_to_status)
+    }
+
+    fn resolve_path(&self, file_name: &U16CStr) -> Result<FileAttr, NTSTATUS> {
+        let components = path_components(file_name);
+        self.block_on(async {
+            let mut attr = self.fs.get_attr(ROOT_INODE).await?;
+            for component in components {
+                if attr.kind != FileType::Directory {
+                    return Err(FsError::InvalidInodeType);
+                }
+                attr = self
+                    .fs
+                    .find_by_name(attr.ino, &secret(&component))
+                    .await?
+                    .ok_or(FsError::NotFound("path component not found"))?;
+            }
+            Ok(attr)
+        })
+    }
+
+    fn resolve_parent(&self, file_name: &U16CStr) -> Result<(u64, SecretString), NTSTATUS> {
+        let mut components = path_components(file_name);
+        let name = components
+            .pop()
+            .ok_or(STATUS_INVALID_PARAMETER)
+            .map(|name| secret(&name))?;
+
+        self.block_on(async {
+            let mut attr = self.fs.get_attr(ROOT_INODE).await?;
+            for component in components {
+                attr = self
+                    .fs
+                    .find_by_name(attr.ino, &secret(&component))
+                    .await?
+                    .ok_or(FsError::NotFound("parent path component not found"))?;
+                if attr.kind != FileType::Directory {
+                    return Err(FsError::InvalidInodeType);
+                }
+            }
+            Ok((attr.ino, name))
+        })
+    }
+
+    fn open_context(
+        &self,
+        attr: FileAttr,
+        granted_access: FileAccessRights,
+    ) -> Result<Arc<WindowsFileContext>, NTSTATUS> {
+        if attr.kind == FileType::Directory {
+            return Ok(Arc::new(WindowsFileContext {
+                ino: attr.ino,
+                handle: Mutex::new(None),
+                is_dir: true,
+                read: false,
+                write: false,
+            }));
+        }
+
+        let (read, write) = access_modes(granted_access);
+        let handle = self.block_on(self.fs.open(attr.ino, read, write))?;
+        Ok(Arc::new(WindowsFileContext {
+            ino: attr.ino,
+            handle: Mutex::new(Some(handle)),
+            is_dir: false,
+            read,
+            write,
+        }))
+    }
+
+    fn context_handle(context: &WindowsFileContext) -> Result<u64, NTSTATUS> {
+        context
+            .handle
+            .lock()
+            .map_err(|_| STATUS_INVALID_HANDLE)?
+            .ok_or(STATUS_INVALID_HANDLE)
+    }
+
+    fn delete_by_name(
+        &self,
+        context: &WindowsFileContext,
+        file_name: &U16CStr,
+    ) -> Result<(), NTSTATUS> {
+        self.release_context(context)?;
+        let (parent, name) = self.resolve_parent(file_name)?;
+        if context.is_dir {
+            self.block_on(self.fs.remove_dir(parent, &name))
+        } else {
+            self.block_on(self.fs.remove_file(parent, &name))
+        }
+    }
+
+    fn release_context(&self, context: &WindowsFileContext) -> Result<(), NTSTATUS> {
+        let mut handle = context.handle.lock().map_err(|_| STATUS_INVALID_HANDLE)?;
+        if let Some(handle) = handle.take() {
+            self.block_on(self.fs.release(handle))?;
+        }
+        Ok(())
+    }
+
+    fn resize_context(&self, context: &WindowsFileContext, new_size: u64) -> Result<(), NTSTATUS> {
+        self.release_context(context)?;
+        self.block_on(self.fs.set_len(context.ino, new_size))?;
+        let handle = self.block_on(self.fs.open(context.ino, context.read, context.write))?;
+        context
+            .handle
+            .lock()
+            .map_err(|_| STATUS_INVALID_HANDLE)?
+            .replace(handle);
+        Ok(())
+    }
+}
+
+impl FileSystemInterface for WindowsFs {
+    type FileContext = Arc<WindowsFileContext>;
+
+    const GET_VOLUME_INFO_DEFINED: bool = true;
+    fn get_volume_info(&self) -> Result<VolumeInfo, NTSTATUS> {
+        Ok(self.volume_info.clone())
+    }
+
+    const GET_SECURITY_BY_NAME_DEFINED: bool = true;
+    fn get_security_by_name(
+        &self,
+        file_name: &U16CStr,
+        _find_reparse_point: impl Fn() -> Option<FileAttributes>,
+    ) -> Result<(FileAttributes, PSecurityDescriptor, bool), NTSTATUS> {
+        let attr = self.resolve_path(file_name)?;
+        Ok((
+            file_attributes(attr.kind),
+            self.security_descriptor.as_ptr(),
+            false,
+        ))
+    }
+
+    const CREATE_DEFINED: bool = true;
+    fn create(
+        &self,
+        file_name: &U16CStr,
+        create_file_info: CreateFileInfo,
+        _security_descriptor: SecurityDescriptor,
+    ) -> Result<(Self::FileContext, FileInfo), NTSTATUS> {
+        if self.read_only {
+            return Err(STATUS_MEDIA_WRITE_PROTECTED);
+        }
+        let (parent, name) = self.resolve_parent(file_name)?;
+        let is_dir = create_file_info
+            .create_options
+            .is(CreateOptions::FILE_DIRECTORY_FILE);
+        let kind = if is_dir {
+            FileType::Directory
+        } else {
+            FileType::RegularFile
+        };
+        let (read, write) = if is_dir {
+            (false, false)
+        } else {
+            access_modes(create_file_info.granted_access)
+        };
+        let create_attr = CreateFileAttr {
+            kind,
+            perm: if is_dir { 0o755 } else { 0o644 },
+            uid: 0,
+            gid: 0,
+            rdev: 0,
+            flags: 0,
+        };
+
+        let (handle, attr) =
+            self.block_on(self.fs.create(parent, &name, create_attr, read, write))?;
+        let context = Arc::new(WindowsFileContext {
+            ino: attr.ino,
+            handle: Mutex::new((handle != 0).then_some(handle)),
+            is_dir,
+            read,
+            write,
+        });
+        Ok((context, attr_to_file_info(attr)))
+    }
+
+    const OPEN_DEFINED: bool = true;
+    fn open(
+        &self,
+        file_name: &U16CStr,
+        create_options: CreateOptions,
+        granted_access: FileAccessRights,
+    ) -> Result<(Self::FileContext, FileInfo), NTSTATUS> {
+        let attr = self.resolve_path(file_name)?;
+        if create_options.is(CreateOptions::FILE_DIRECTORY_FILE) && attr.kind != FileType::Directory
+        {
+            return Err(STATUS_NOT_A_DIRECTORY);
+        }
+        if create_options.is(CreateOptions::FILE_NON_DIRECTORY_FILE)
+            && attr.kind == FileType::Directory
+        {
+            return Err(STATUS_FILE_IS_A_DIRECTORY);
+        }
+        let context = self.open_context(attr, granted_access)?;
+        Ok((context, attr_to_file_info(attr)))
+    }
+
+    const OVERWRITE_DEFINED: bool = true;
+    fn overwrite(
+        &self,
+        file_context: Self::FileContext,
+        _file_attributes: FileAttributes,
+        _replace_file_attributes: bool,
+        _allocation_size: u64,
+    ) -> Result<FileInfo, NTSTATUS> {
+        if self.read_only {
+            return Err(STATUS_MEDIA_WRITE_PROTECTED);
+        }
+        if file_context.is_dir {
+            return Err(STATUS_FILE_IS_A_DIRECTORY);
+        }
+        self.resize_context(&file_context, 0)?;
+        self.block_on(self.fs.get_attr(file_context.ino))
+            .map(attr_to_file_info)
+    }
+
+    const CLEANUP_DEFINED: bool = true;
+    fn cleanup(
+        &self,
+        file_context: Self::FileContext,
+        file_name: Option<&U16CStr>,
+        flags: CleanupFlags,
+    ) {
+        if self.read_only || !flags.is(CleanupFlags::DELETE) {
+            return;
+        }
+        if let Some(file_name) = file_name {
+            if let Err(status) = self.delete_by_name(&file_context, file_name) {
+                error!(status, "WinFSP cleanup delete failed");
+            }
+        }
+    }
+
+    const CLOSE_DEFINED: bool = true;
+    fn close(&self, file_context: Self::FileContext) {
+        if let Err(status) = self.release_context(&file_context) {
+            error!(status, "WinFSP release failed");
+        }
+    }
+
+    const READ_DEFINED: bool = true;
+    fn read(
+        &self,
+        file_context: Self::FileContext,
+        buffer: &mut [u8],
+        offset: u64,
+    ) -> Result<usize, NTSTATUS> {
+        if file_context.is_dir {
+            return Err(STATUS_FILE_IS_A_DIRECTORY);
+        }
+        let attr = self.block_on(self.fs.get_attr(file_context.ino))?;
+        if offset >= attr.size {
+            return Err(STATUS_END_OF_FILE);
+        }
+        let handle = Self::context_handle(&file_context)?;
+        self.block_on(self.fs.read(file_context.ino, offset, buffer, handle))
+    }
+
+    const WRITE_DEFINED: bool = true;
+    fn write(
+        &self,
+        file_context: Self::FileContext,
+        buffer: &[u8],
+        mode: WriteMode,
+    ) -> Result<(usize, FileInfo), NTSTATUS> {
+        if self.read_only {
+            return Err(STATUS_MEDIA_WRITE_PROTECTED);
+        }
+        if file_context.is_dir {
+            return Err(STATUS_FILE_IS_A_DIRECTORY);
+        }
+        let handle = Self::context_handle(&file_context)?;
+        let attr = self.block_on(self.fs.get_attr(file_context.ino))?;
+        let (offset, write_buffer) = match mode {
+            WriteMode::Normal { offset } => (offset, buffer),
+            WriteMode::WriteToEOF => (attr.size, buffer),
+            WriteMode::ConstrainedIO { offset } => {
+                if offset >= attr.size {
+                    return Ok((0, attr_to_file_info(attr)));
+                }
+                let allowed = usize::try_from((attr.size - offset).min(buffer.len() as u64))
+                    .map_err(|_| STATUS_INVALID_PARAMETER)?;
+                (offset, &buffer[..allowed])
+            }
+        };
+        let written =
+            self.block_on(
+                self.fs
+                    .write(file_context.ino, offset, write_buffer, handle),
+            )?;
+        let attr = self.block_on(self.fs.get_attr(file_context.ino))?;
+        Ok((written, attr_to_file_info(attr)))
+    }
+
+    const FLUSH_DEFINED: bool = true;
+    fn flush(&self, file_context: Self::FileContext) -> Result<FileInfo, NTSTATUS> {
+        if !self.read_only && !file_context.is_dir {
+            let handle = Self::context_handle(&file_context)?;
+            self.block_on(self.fs.flush(handle))?;
+        }
+        self.block_on(self.fs.get_attr(file_context.ino))
+            .map(attr_to_file_info)
+    }
+
+    const GET_FILE_INFO_DEFINED: bool = true;
+    fn get_file_info(&self, file_context: Self::FileContext) -> Result<FileInfo, NTSTATUS> {
+        self.block_on(self.fs.get_attr(file_context.ino))
+            .map(attr_to_file_info)
+    }
+
+    const SET_BASIC_INFO_DEFINED: bool = true;
+    fn set_basic_info(
+        &self,
+        file_context: Self::FileContext,
+        _file_attributes: FileAttributes,
+        creation_time: u64,
+        last_access_time: u64,
+        last_write_time: u64,
+        change_time: u64,
+    ) -> Result<FileInfo, NTSTATUS> {
+        if self.read_only {
+            return Err(STATUS_MEDIA_WRITE_PROTECTED);
+        }
+        let mut update = SetFileAttr::default();
+        if creation_time != 0 {
+            update.crtime = Some(system_time_from_filetime(creation_time));
+        }
+        if last_access_time != 0 {
+            update.atime = Some(system_time_from_filetime(last_access_time));
+        }
+        if last_write_time != 0 {
+            update.mtime = Some(system_time_from_filetime(last_write_time));
+        }
+        if change_time != 0 {
+            update.ctime = Some(system_time_from_filetime(change_time));
+        }
+        self.block_on(self.fs.set_attr(file_context.ino, update))?;
+        self.block_on(self.fs.get_attr(file_context.ino))
+            .map(attr_to_file_info)
+    }
+
+    const SET_FILE_SIZE_DEFINED: bool = true;
+    fn set_file_size(
+        &self,
+        file_context: Self::FileContext,
+        new_size: u64,
+        set_allocation_size: bool,
+    ) -> Result<FileInfo, NTSTATUS> {
+        if self.read_only {
+            return Err(STATUS_MEDIA_WRITE_PROTECTED);
+        }
+        if file_context.is_dir {
+            return Err(STATUS_FILE_IS_A_DIRECTORY);
+        }
+        let current = self.block_on(self.fs.get_attr(file_context.ino))?;
+        if !set_allocation_size || new_size < current.size {
+            self.resize_context(&file_context, new_size)?;
+        }
+        self.block_on(self.fs.get_attr(file_context.ino))
+            .map(attr_to_file_info)
+    }
+
+    const SET_DELETE_DEFINED: bool = true;
+    fn set_delete(
+        &self,
+        file_context: Self::FileContext,
+        _file_name: &U16CStr,
+        delete_file: bool,
+    ) -> Result<(), NTSTATUS> {
+        if self.read_only {
+            return Err(STATUS_MEDIA_WRITE_PROTECTED);
+        }
+        if delete_file && file_context.is_dir {
+            let len = self.fs.len(file_context.ino).map_err(fs_error_to_status)?;
+            if len > 0 {
+                return Err(STATUS_DIRECTORY_NOT_EMPTY);
+            }
+        }
+        Ok(())
+    }
+
+    const RENAME_DEFINED: bool = true;
+    fn rename(
+        &self,
+        _file_context: Self::FileContext,
+        file_name: &U16CStr,
+        new_file_name: &U16CStr,
+        replace_if_exists: bool,
+    ) -> Result<(), NTSTATUS> {
+        if self.read_only {
+            return Err(STATUS_MEDIA_WRITE_PROTECTED);
+        }
+        let (parent, name) = self.resolve_parent(file_name)?;
+        let (new_parent, new_name) = self.resolve_parent(new_file_name)?;
+        if parent == new_parent && name.expose_secret() == new_name.expose_secret() {
+            return Ok(());
+        }
+        if let Some(existing) = self.block_on(self.fs.find_by_name(new_parent, &new_name))? {
+            if !replace_if_exists {
+                return Err(STATUS_OBJECT_NAME_COLLISION);
+            }
+            if existing.kind == FileType::Directory {
+                self.block_on(self.fs.remove_dir(new_parent, &new_name))?;
+            } else {
+                self.block_on(self.fs.remove_file(new_parent, &new_name))?;
+            }
+        }
+        self.block_on(self.fs.rename(parent, &name, new_parent, &new_name))
+    }
+
+    const GET_SECURITY_DEFINED: bool = true;
+    fn get_security(
+        &self,
+        _file_context: Self::FileContext,
+    ) -> Result<PSecurityDescriptor, NTSTATUS> {
+        Ok(self.security_descriptor.as_ptr())
+    }
+
+    const READ_DIRECTORY_DEFINED: bool = true;
+    fn read_directory(
+        &self,
+        file_context: Self::FileContext,
+        marker: Option<&U16CStr>,
+        mut add_dir_info: impl FnMut(DirInfo) -> bool,
+    ) -> Result<(), NTSTATUS> {
+        if !file_context.is_dir {
+            return Err(STATUS_NOT_A_DIRECTORY);
+        }
+        let iter = self.block_on(self.fs.read_dir_plus(file_context.ino))?;
+        let marker = marker.map(U16CStr::to_string_lossy);
+        let mut entries = Vec::new();
+        for entry in iter {
+            let entry = entry.map_err(fs_error_to_status)?;
+            entries.push((
+                entry.name.expose_secret().to_string(),
+                attr_to_file_info(entry.attr),
+            ));
+        }
+        entries.sort_by(|left, right| left.0.cmp(&right.0));
+
+        for (name, info) in entries {
+            if marker
+                .as_deref()
+                .is_some_and(|marker| name.as_str() <= marker)
+            {
+                continue;
+            }
+            if name.encode_utf16().count() >= 255 {
+                continue;
+            }
+            if !add_dir_info(DirInfo::from_str(info, &name)) {
+                break;
+            }
+        }
+        Ok(())
+    }
+}
+
+fn path_components(file_name: &U16CStr) -> Vec<String> {
+    file_name
+        .to_string_lossy()
+        .split(['\\', '/'])
+        .filter(|component| !component.is_empty() && *component != ".")
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+fn secret(value: &str) -> SecretString {
+    SecretString::new(Box::new(value.to_owned()))
+}
+
+fn access_modes(granted_access: FileAccessRights) -> (bool, bool) {
+    let read = granted_access.0
+        & (FileAccessRights::FILE_READ_DATA.0 | FileAccessRights::FILE_GENERIC_READ.0)
+        != 0;
+    let write = granted_access.0
+        & (FileAccessRights::FILE_WRITE_DATA.0
+            | FileAccessRights::FILE_APPEND_DATA.0
+            | FileAccessRights::FILE_GENERIC_WRITE.0)
+        != 0;
+    if read || write {
+        (read, write)
+    } else {
+        // Attribute-only opens still need a backing rencfs handle if a later
+        // cached read is issued for the same Windows file object.
+        (true, false)
+    }
+}
+
+fn file_attributes(kind: FileType) -> FileAttributes {
+    match kind {
+        FileType::Directory => FileAttributes::DIRECTORY,
+        FileType::RegularFile => FileAttributes::ARCHIVE,
+    }
+}
+
+fn attr_to_file_info(attr: FileAttr) -> FileInfo {
+    let mut info = FileInfo::default();
+    info.set_file_attributes(file_attributes(attr.kind))
+        .set_allocation_size(attr.size.div_ceil(ALLOCATION_UNIT) * ALLOCATION_UNIT)
+        .set_file_size(attr.size)
+        .set_creation_time(filetime_from_system_time(attr.crtime))
+        .set_last_access_time(filetime_from_system_time(attr.atime))
+        .set_last_write_time(filetime_from_system_time(attr.mtime))
+        .set_change_time(filetime_from_system_time(attr.ctime))
+        .set_index_number(attr.ino)
+        .set_hard_links(attr.nlink);
+    info
+}
+
+fn filetime_from_system_time(time: SystemTime) -> u64 {
+    const WINDOWS_EPOCH_OFFSET: u64 = 116_444_736_000_000_000;
+    let duration = time.duration_since(UNIX_EPOCH).unwrap_or_default();
+    WINDOWS_EPOCH_OFFSET
+        + duration.as_secs() * 10_000_000
+        + u64::from(duration.subsec_nanos()) / 100
+}
+
+fn system_time_from_filetime(filetime: u64) -> SystemTime {
+    const WINDOWS_EPOCH_OFFSET: u64 = 116_444_736_000_000_000;
+    if filetime <= WINDOWS_EPOCH_OFFSET {
+        return UNIX_EPOCH;
+    }
+    let ticks = filetime - WINDOWS_EPOCH_OFFSET;
+    UNIX_EPOCH + Duration::new(ticks / 10_000_000, ((ticks % 10_000_000) * 100) as u32)
+}
+
+fn fs_error_to_status(error: FsError) -> NTSTATUS {
+    match error {
+        FsError::NotFound(_) | FsError::InodeNotFound => STATUS_OBJECT_NAME_NOT_FOUND,
+        FsError::AlreadyExists => STATUS_OBJECT_NAME_COLLISION,
+        FsError::NotEmpty => STATUS_DIRECTORY_NOT_EMPTY,
+        FsError::ReadOnly => STATUS_MEDIA_WRITE_PROTECTED,
+        FsError::InvalidInodeType => STATUS_NOT_A_DIRECTORY,
+        FsError::InvalidFileHandle => STATUS_INVALID_HANDLE,
+        FsError::InvalidInput(_) => STATUS_INVALID_PARAMETER,
+        FsError::MaxFilesizeExceeded(_) => STATUS_DISK_FULL,
+        FsError::AlreadyOpenForWrite => STATUS_ACCESS_DENIED,
+        FsError::InvalidDataDirStructure => STATUS_OBJECT_PATH_NOT_FOUND,
+        _ => STATUS_UNEXPECTED_IO_ERROR,
+    }
+}
+
+#[allow(clippy::struct_excessive_bools)]
+pub struct MountPointImpl {
+    mountpoint: PathBuf,
+    data_dir: PathBuf,
+    password_provider: Option<Box<dyn PasswordProvider>>,
+    cipher: Cipher,
+    read_only: bool,
+}
+
+#[async_trait]
+impl MountPoint for MountPointImpl {
+    fn new(
+        mountpoint: PathBuf,
+        data_dir: PathBuf,
+        password_provider: Box<dyn PasswordProvider>,
+        cipher: Cipher,
+        _allow_root: bool,
+        _allow_other: bool,
+        read_only: bool,
+    ) -> Self {
+        Self {
+            mountpoint,
+            data_dir,
+            password_provider: Some(password_provider),
+            cipher,
+            read_only,
+        }
+    }
+
+    async fn mount(mut self) -> FsResult<mount::MountHandle> {
+        winfsp_wrs::init().map_err(|err| {
+            error!(err = %err, "cannot initialize WinFSP");
+            FsError::Other("cannot initialize WinFSP")
+        })?;
+        let encrypted_fs = EncryptedFs::new(
+            self.data_dir,
+            self.password_provider.take().unwrap(),
+            self.cipher,
+            self.read_only,
+        )
+        .await?;
+        let context = WindowsFs::new(encrypted_fs, self.read_only)?;
+        let mountpoint = U16CString::from_os_str(self.mountpoint.as_os_str())
+            .map_err(|_| FsError::InvalidInput("invalid Windows mount point"))?;
+
+        let mut volume_params = VolumeParams::default();
+        volume_params
+            .set_sector_size(512)
+            .set_sectors_per_allocation_unit((ALLOCATION_UNIT / 512) as u16)
+            .set_volume_creation_time(filetime_from_system_time(SystemTime::now()))
+            .set_volume_serial_number(0x5245_4E43)
+            .set_file_info_timeout(1000)
+            .set_case_sensitive_search(true)
+            .set_case_preserved_names(true)
+            .set_unicode_on_disk(true)
+            .set_post_cleanup_when_modified_only(true)
+            .set_read_only_volume(self.read_only);
+        volume_params
+            .set_file_system_name(u16cstr!("rencfs"))
+            .map_err(|_| FsError::Other("invalid filesystem name"))?;
+        volume_params
+            .set_prefix(u16cstr!(""))
+            .map_err(|_| FsError::Other("invalid filesystem prefix"))?;
+
+        info!(mountpoint = %mountpoint.to_string_lossy(), "mounting WinFSP filesystem");
+        let filesystem = FileSystem::start(
+            Params {
+                volume_params,
+                ..Default::default()
+            },
+            Some(&mountpoint),
+            context,
+        )
+        .map_err(|status| {
+            error!(status, "cannot start WinFSP filesystem");
+            FsError::Other("cannot start WinFSP filesystem")
+        })?;
+
+        Ok(mount::MountHandle {
+            inner: MountHandleInnerImpl {
+                filesystem: Some(filesystem),
+            },
+        })
+    }
+}
+
+pub(in crate::mount) struct MountHandleInnerImpl {
+    filesystem: Option<FileSystem>,
+}
+
+impl Future for MountHandleInnerImpl {
+    type Output = io::Result<()>;
+
+    fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+        Poll::Pending
+    }
+}
+
+#[async_trait]
+impl MountHandleInner for MountHandleInnerImpl {
+    async fn unmount(mut self) -> io::Result<()> {
+        if let Some(filesystem) = self.filesystem.take() {
+            filesystem.stop();
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+    use tempfile::tempdir;
+
+    struct TestPasswordProvider;
+
+    impl PasswordProvider for TestPasswordProvider {
+        fn get_password(&self) -> Option<SecretString> {
+            Some(SecretString::from_str("winfsp-adapter-test").unwrap())
+        }
+    }
+
+    fn test_security_descriptor() -> SecurityDescriptor {
+        SecurityDescriptor::from_wstr(u16cstr!("O:BAG:BAD:P(A;;FA;;;SY)(A;;FA;;;BA)(A;;FA;;;WD)"))
+            .unwrap()
+    }
+
+    fn file_create_info() -> CreateFileInfo {
+        CreateFileInfo {
+            create_options: CreateOptions::FILE_NON_DIRECTORY_FILE,
+            granted_access: FileAccessRights::FILE_GENERIC_READ
+                | FileAccessRights::FILE_GENERIC_WRITE,
+            file_attributes: FileAttributes::ARCHIVE,
+            // This is a reservation hint, not the logical file length.
+            allocation_size: 64 * 1024,
+        }
+    }
+
+    fn dir_info_name(info: &DirInfo) -> String {
+        let len = info
+            .file_name
+            .iter()
+            .position(|unit| *unit == 0)
+            .unwrap_or(info.file_name.len());
+        String::from_utf16_lossy(&info.file_name[..len])
+    }
+
+    #[test]
+    fn path_components_handle_windows_and_root_paths() {
+        let nested = U16CString::from_str(r"\alpha\beta").unwrap();
+        assert_eq!(path_components(&nested), ["alpha", "beta"]);
+
+        let root = U16CString::from_str(r"\").unwrap();
+        assert!(path_components(&root).is_empty());
+    }
+
+    #[test]
+    fn filetime_round_trip_is_stable_to_one_hundred_nanoseconds() {
+        let original = UNIX_EPOCH + Duration::new(1_234_567, 890_123_400);
+        let round_trip = system_time_from_filetime(filetime_from_system_time(original));
+        assert_eq!(original, round_trip);
+    }
+
+    #[test]
+    fn adapter_supports_basic_file_lifecycle_without_mounting_driver() {
+        let data_dir = tempdir().unwrap();
+        let setup_runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let encrypted_fs = setup_runtime
+            .block_on(EncryptedFs::new(
+                data_dir.path().to_path_buf(),
+                Box::new(TestPasswordProvider),
+                Cipher::ChaCha20Poly1305,
+                false,
+            ))
+            .unwrap();
+        drop(setup_runtime);
+
+        let adapter = WindowsFs::new(encrypted_fs, false).unwrap();
+        let original_name = U16CString::from_str(r"\hello.txt").unwrap();
+        let renamed_name = U16CString::from_str(r"\renamed.txt").unwrap();
+        let replacement_name = U16CString::from_str(r"\replacement.txt").unwrap();
+        let root_name = U16CString::from_str(r"\").unwrap();
+
+        let (write_context, created) = adapter
+            .create(
+                &original_name,
+                file_create_info(),
+                test_security_descriptor(),
+            )
+            .unwrap();
+        assert_eq!(created.file_size(), 0);
+
+        let initial_payload = b"hello before truncate";
+        let (written, written_info) = adapter
+            .write(
+                write_context.clone(),
+                initial_payload,
+                WriteMode::Normal { offset: 0 },
+            )
+            .unwrap();
+        assert_eq!(written, initial_payload.len());
+        assert_eq!(written_info.file_size(), initial_payload.len() as u64);
+        let truncated = adapter
+            .set_file_size(write_context.clone(), 5, false)
+            .unwrap();
+        assert_eq!(truncated.file_size(), 5);
+        let suffix = b" from WinFSP";
+        adapter
+            .write(write_context.clone(), suffix, WriteMode::WriteToEOF)
+            .unwrap();
+        adapter.flush(write_context.clone()).unwrap();
+        adapter.close(write_context);
+
+        let payload = b"hello from WinFSP";
+        let (read_context, _) = adapter
+            .open(
+                &original_name,
+                CreateOptions::FILE_NON_DIRECTORY_FILE,
+                FileAccessRights::FILE_GENERIC_READ,
+            )
+            .unwrap();
+        let mut read_buffer = vec![0; payload.len()];
+        let read = adapter
+            .read(read_context.clone(), &mut read_buffer, 0)
+            .unwrap();
+        assert_eq!(read, payload.len());
+        assert_eq!(read_buffer, payload);
+
+        adapter
+            .rename(read_context.clone(), &original_name, &renamed_name, false)
+            .unwrap();
+        assert!(adapter.resolve_path(&original_name).is_err());
+        assert_eq!(
+            adapter.resolve_path(&renamed_name).unwrap().size,
+            payload.len() as u64
+        );
+        adapter.close(read_context);
+
+        let (root_context, _) = adapter
+            .open(
+                &root_name,
+                CreateOptions::FILE_DIRECTORY_FILE,
+                FileAccessRights::FILE_LIST_DIRECTORY,
+            )
+            .unwrap();
+        let mut names = Vec::new();
+        adapter
+            .read_directory(root_context.clone(), None, |entry| {
+                names.push(dir_info_name(&entry));
+                true
+            })
+            .unwrap();
+        assert!(names.iter().any(|name| name == "renamed.txt"));
+        adapter.close(root_context);
+
+        let (replacement_context, _) = adapter
+            .create(
+                &replacement_name,
+                file_create_info(),
+                test_security_descriptor(),
+            )
+            .unwrap();
+        adapter.close(replacement_context);
+        let (rename_context, _) = adapter
+            .open(
+                &renamed_name,
+                CreateOptions::FILE_NON_DIRECTORY_FILE,
+                FileAccessRights::FILE_GENERIC_READ | FileAccessRights::DELETE,
+            )
+            .unwrap();
+        adapter
+            .rename(
+                rename_context.clone(),
+                &renamed_name,
+                &replacement_name,
+                true,
+            )
+            .unwrap();
+        adapter.close(rename_context);
+        assert!(adapter.resolve_path(&renamed_name).is_err());
+        assert_eq!(
+            adapter.resolve_path(&replacement_name).unwrap().size,
+            payload.len() as u64
+        );
+
+        let (delete_context, _) = adapter
+            .open(
+                &replacement_name,
+                CreateOptions::FILE_NON_DIRECTORY_FILE,
+                FileAccessRights::FILE_GENERIC_READ | FileAccessRights::DELETE,
+            )
+            .unwrap();
+        adapter
+            .set_delete(delete_context.clone(), &replacement_name, true)
+            .unwrap();
+        adapter.cleanup(
+            delete_context.clone(),
+            Some(&replacement_name),
+            CleanupFlags::DELETE,
+        );
+        adapter.close(delete_context);
+        assert!(adapter.resolve_path(&replacement_name).is_err());
+    }
+}


### PR DESCRIPTION
## Description

Adds a basic native Windows mount implementation backed by WinFSP and the existing `EncryptedFs`.

Key changes:

- implement WinFSP callbacks for create/open/read/write/flush/resize/rename/delete, metadata, security, and directory enumeration
- enable the existing CLI on Windows and cleanly stop the WinFSP filesystem through `MountHandle`
- make rencfs storage Windows-safe (`|`, trailing-dot directory entries, directory/file flush behavior)
- keep legacy Unix storage names readable for cross-platform compatibility
- document WinFSP installation and Windows drive-letter mounts
- install a checksum-pinned WinFSP MSI in Windows CI
- add callback-level lifecycle tests and an end-to-end `R:` mount smoke test

The Rust binding is [`winfsp_wrs`](https://github.com/Scille/winfsp_wrs), which is MIT-licensed. WinFSP remains a separately installed runtime/driver and publishes its GPLv3 license with the WinFSP Free/Libre and Open Source Software exception.

This also exposed a Windows `VirtualUnlock` panic in `shush-rs`; the dependency is temporarily pinned to the tested fix from [Eyob94/shush-rs#22](https://github.com/Eyob94/shush-rs/pull/22).

Fixes #3

---

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

---

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have tested my code on different platforms (GitHub's Linux/macOS/Windows matrix is configured for this PR)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added necessary documentation
- [x] My changes generate no new code warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (focused Windows tests pass; the repository already skips the full suite on Windows)

---

## Validation

- `cargo test --release --lib mount::windows::tests`: 3 passed
- adapter test covers initialization, create, write, truncate/reopen, append, flush, read, rename with replacement, enumerate, and delete
- `cargo build --release --all-targets --all-features`: passed
- repository Clippy command: passed
- `cargo fmt --all -- --check`: passed
- `cargo package --allow-dirty --no-verify`: passed

The GitHub Windows job additionally installs WinFSP and performs a real mounted-drive create/read/rename/delete smoke test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Windows support through WinFSP, including mounting, file operations, read-only mode, and unmounting.
  * Added Windows-safe encrypted filename handling and cross-platform path compatibility.
  * Added reliable file and directory synchronization across platforms.
  * Improved rename operations with replacement support and safer recovery when operations fail.

* **Documentation**
  * Updated Linux and Windows setup and mounting instructions, including WinFSP requirements and drive-letter examples.

* **Tests**
  * Added Windows adapter coverage and an end-to-end mount smoke test for common file operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->